### PR TITLE
feat: option to treat FAUX as ESM

### DIFF
--- a/packages/node-modules-inspector/src/app/components/panel/Filters.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/Filters.vue
@@ -4,14 +4,7 @@ import type { WritableComputedRef } from 'vue'
 import { computed } from 'vue'
 import { filters } from '~/state/filters'
 import { payloads } from '~/state/payload'
-import { settings } from '~/state/settings'
-import { MODULE_TYPES_FULL_SELECT, MODULE_TYPES_SIMPLE_SELECT } from '../../utils/module-type'
-
-const moduleTypesAvailable = computed<PackageModuleType[]>(() =>
-  settings.value.moduleTypeSimple
-    ? MODULE_TYPES_SIMPLE_SELECT
-    : MODULE_TYPES_FULL_SELECT,
-)
+import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailable } from '../../utils/module-type'
 
 function createModuleTypeRef(name: PackageModuleType) {
   return computed({

--- a/packages/node-modules-inspector/src/app/components/panel/Filters.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/Filters.vue
@@ -4,7 +4,7 @@ import type { WritableComputedRef } from 'vue'
 import { computed } from 'vue'
 import { filters } from '~/state/filters'
 import { payloads } from '~/state/payload'
-import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailable } from '../../utils/module-type'
+import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailableSelect } from '../../utils/module-type'
 
 function createModuleTypeRef(name: PackageModuleType) {
   return computed({
@@ -12,13 +12,13 @@ function createModuleTypeRef(name: PackageModuleType) {
       return filters.state.modules == null || filters.state.modules.includes(name)
     },
     set(v) {
-      const current = new Set(filters.state.modules ? filters.state.modules : moduleTypesAvailable.value)
+      const current = new Set(filters.state.modules ? filters.state.modules : moduleTypesAvailableSelect.value)
       if (v)
         current.add(name)
       else
         current.delete(name)
 
-      if (current.size >= moduleTypesAvailable.value.length) {
+      if (current.size >= moduleTypesAvailableSelect.value.length) {
         filters.state.modules = null
       }
       else {
@@ -84,7 +84,7 @@ const moduleTypes = Object.fromEntries(
     <div flex="~ col gap-2" p4 border="t base">
       <div flex="~ gap-4 wrap">
         <label
-          v-for="type of moduleTypesAvailable"
+          v-for="type of moduleTypesAvailableSelect"
           :key="type"
           flex="~ gap-1 items-center"
         >

--- a/packages/node-modules-inspector/src/app/components/panel/FiltersMini.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/FiltersMini.vue
@@ -4,14 +4,7 @@ import type { WritableComputedRef } from 'vue'
 import { computed } from 'vue'
 import { filters, FILTERS_DEFAULT } from '~/state/filters'
 import { query } from '~/state/query'
-import { settings } from '~/state/settings'
-import { MODULE_TYPES_FULL_SELECT, MODULE_TYPES_SIMPLE_SELECT } from '~/utils/module-type'
-
-const moduleTypesAvailable = computed<PackageModuleType[]>(() =>
-  settings.value.moduleTypeSimple
-    ? MODULE_TYPES_SIMPLE_SELECT
-    : MODULE_TYPES_FULL_SELECT,
-)
+import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailable } from '~/utils/module-type'
 
 function createModuleTypeRef(name: PackageModuleType) {
   return computed({

--- a/packages/node-modules-inspector/src/app/components/panel/FiltersMini.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/FiltersMini.vue
@@ -4,7 +4,7 @@ import type { WritableComputedRef } from 'vue'
 import { computed } from 'vue'
 import { filters, FILTERS_DEFAULT } from '~/state/filters'
 import { query } from '~/state/query'
-import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailable } from '~/utils/module-type'
+import { MODULE_TYPES_FULL_SELECT, moduleTypesAvailableSelect } from '~/utils/module-type'
 
 function createModuleTypeRef(name: PackageModuleType) {
   return computed({
@@ -12,13 +12,13 @@ function createModuleTypeRef(name: PackageModuleType) {
       return filters.state.modules == null || filters.state.modules.includes(name)
     },
     set(v) {
-      const current = new Set(filters.state.modules ? filters.state.modules : moduleTypesAvailable.value)
+      const current = new Set(filters.state.modules ? filters.state.modules : moduleTypesAvailableSelect.value)
       if (v)
         current.add(name)
       else
         current.delete(name)
 
-      if (current.size >= moduleTypesAvailable.value.length) {
+      if (current.size >= moduleTypesAvailableSelect.value.length) {
         filters.state.modules = null
       }
       else {
@@ -59,7 +59,7 @@ const moduleTypes = Object.fromEntries(
     </div>
     <div v-if="filters.state.modules !== FILTERS_DEFAULT.modules" border="l base" flex="~ gap-1 items-center" px2>
       <template
-        v-for="type of moduleTypesAvailable"
+        v-for="type of moduleTypesAvailableSelect"
         :key="type"
       >
         <DisplayModuleType

--- a/packages/node-modules-inspector/src/app/components/panel/Settings.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/Settings.vue
@@ -12,6 +12,9 @@ const backend = getBackend()
       <OptionItem title="Simplify module types" description="Show only ESM/CJS">
         <OptionCheckbox v-model="settings.moduleTypeSimple" />
       </OptionItem>
+      <OptionItem title="Treat FAUX as ESM" description="Treat FAUX as ESM">
+        <OptionCheckbox v-model="settings.treatFauxAsESM" />
+      </OptionItem>
       <OptionItem title="Module type indicator" description="Rendering mode of module type indicator">
         <OptionSelectGroup
           v-model="settings.moduleTypeRender"

--- a/packages/node-modules-inspector/src/app/state/settings.ts
+++ b/packages/node-modules-inspector/src/app/state/settings.ts
@@ -9,6 +9,7 @@ export interface Settings {
   showInstallSizeBadge: boolean
   showPublishTimeBadge: boolean
   showFileComposition: boolean
+  treatFauxAsESM: boolean
 }
 
 export const settings = useLocalStorage<Settings>(
@@ -22,6 +23,7 @@ export const settings = useLocalStorage<Settings>(
     showInstallSizeBadge: true,
     showPublishTimeBadge: false,
     showFileComposition: false,
+    treatFauxAsESM: false,
   },
   {
     deep: true,

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -19,6 +19,8 @@ export const MODULE_TYPES_COLOR_BADGE = {
 export function getModuleType(node: PackageNode | PackageModuleType) {
   const type = typeof node === 'string' ? node : node.resolved.module
 
+  if (settings.value.treatFauxAsESM && type === 'faux')
+    return 'esm'
   if (!settings.value.moduleTypeSimple)
     return type
 

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -1,11 +1,9 @@
 import type { PackageModuleType, PackageNode } from 'node-modules-tools'
+import { computed } from 'vue'
 import { settings } from '~/state/settings'
 
 export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts'] as PackageModuleType[]
-export const MODULE_TYPES_SIMPLE = ['esm', 'cjs', 'dts'] as PackageModuleType[]
-
 export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs'] as PackageModuleType[]
-export const MODULE_TYPES_SIMPLE_SELECT = ['esm', 'cjs'] as PackageModuleType[]
 
 // @unocss-include
 export const MODULE_TYPES_COLOR_BADGE = {
@@ -39,3 +37,37 @@ export function getModuleTypeCounts(nodes: Iterable<PackageNode>) {
   }
   return counts
 }
+
+/**
+ * Available module types, excluding DTS.
+ *
+ * Used in filters.
+ */
+export const moduleTypesAvailable = computed(() => {
+  const baseTypes = new Set(MODULE_TYPES_FULL_SELECT)
+
+  if (settings.value.treatFauxAsESM)
+    baseTypes.delete('faux')
+  if (settings.value.moduleTypeSimple) {
+    baseTypes.delete('dual')
+    baseTypes.delete('faux')
+  }
+
+  return Array.from(baseTypes)
+})
+
+/**
+ * Available module types, including DTS
+ */
+export const moduleTypesAvailableFull = computed(() => {
+  const baseTypes = new Set(MODULE_TYPES_FULL)
+
+  if (settings.value.treatFauxAsESM)
+    baseTypes.delete('faux')
+  if (settings.value.moduleTypeSimple) {
+    baseTypes.delete('dual')
+    baseTypes.delete('faux')
+  }
+
+  return Array.from(baseTypes)
+})

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -39,12 +39,10 @@ export function getModuleTypeCounts(nodes: Iterable<PackageNode>) {
 }
 
 /**
- * Available module types, excluding DTS.
- *
- * Used in filters.
+ * Currently available module types
  */
 export const moduleTypesAvailable = computed(() => {
-  const baseTypes = new Set(MODULE_TYPES_FULL_SELECT)
+  const baseTypes = new Set(MODULE_TYPES_FULL)
 
   if (settings.value.treatFauxAsESM)
     baseTypes.delete('faux')
@@ -57,10 +55,10 @@ export const moduleTypesAvailable = computed(() => {
 })
 
 /**
- * Available module types, including DTS
+ * Currently available module types, excluding DTS.
  */
-export const moduleTypesAvailableFull = computed(() => {
-  const baseTypes = new Set(MODULE_TYPES_FULL)
+export const moduleTypesAvailableSelect = computed(() => {
+  const baseTypes = new Set(MODULE_TYPES_FULL_SELECT)
 
   if (settings.value.treatFauxAsESM)
     baseTypes.delete('faux')


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds the option to treat FAUX modules as ESM, per #13

### Linked Issues

#13

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I removed the variations of constants for module types, and instead used a computed. This only affects the filters.
