### PR TITLE
feat: page loading spinner

### DIFF
--- a/packages/node-modules-inspector/src/app/components/ui/OffsettedContainer.vue
+++ b/packages/node-modules-inspector/src/app/components/ui/OffsettedContainer.vue
@@ -1,5 +1,0 @@
-<template>
-  <div pt-22 pl-112 pr-8 pb-8>
-    <slot />
-  </div>
-</template>

--- a/packages/node-modules-inspector/src/app/entries/main.vue
+++ b/packages/node-modules-inspector/src/app/entries/main.vue
@@ -53,8 +53,8 @@ setupQuery()
       </div>
     </div>
   </div>
-  <div v-else>
-    <PanelNav />
-    <NuxtPage />
-  </div>
+  <PanelNav v-else />
+  <NuxtLayout>
+    <NuxtPage v-if="!isLoading" />
+  </NuxtLayout>
 </template>

--- a/packages/node-modules-inspector/src/app/layouts/default.vue
+++ b/packages/node-modules-inspector/src/app/layouts/default.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
+import { useRuntimeHook } from '#app/composables/runtime-hook'
+import { ref } from 'vue'
+
 const isLoading = ref(false)
 
-useRuntimeHook('page:loading:start', () => { isLoading.value = true })
-useRuntimeHook('page:loading:end', () => { isLoading.value = false })
+useRuntimeHook('page:loading:start', () => {
+  isLoading.value = true
+})
+useRuntimeHook('page:loading:end', () => {
+  isLoading.value = false
+})
 </script>
 
 <template>

--- a/packages/node-modules-inspector/src/app/layouts/default.vue
+++ b/packages/node-modules-inspector/src/app/layouts/default.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+const isLoading = ref(false)
+
+useRuntimeHook('page:loading:start', () => { isLoading.value = true })
+useRuntimeHook('page:loading:end', () => { isLoading.value = false })
+</script>
+
+<template>
+  <div
+    v-if="isLoading"
+    flex="~ items-center justify-center" h-full page-padding bg-glass:50
+    absolute left-0 top-0 w-full z-49
+    animate-fade-in animate-delay-200 animate-fill-both animate-duration-0
+  >
+    <UiLogo
+      w-30 h-30 transition-all duration-300
+      animate="~ spin reverse"
+    />
+  </div>
+  <div
+    :class="{
+      'page-padding': !$route.meta.noOffset,
+    }"
+  >
+    <slot />
+  </div>
+</template>

--- a/packages/node-modules-inspector/src/app/pages/compare.vue
+++ b/packages/node-modules-inspector/src/app/pages/compare.vue
@@ -21,7 +21,7 @@ const rootPackages = computed(() => {
     .filter(x => !!x)
 })
 
-const showGraph = computed(() => filters.state['compare-a']?.length || filters.state['compare-b']?.length)
+const showGraph = computed(() => filters.state['compare-a']?.length && filters.state['compare-b']?.length)
 
 definePageMeta({
   noOffset: showGraph,

--- a/packages/node-modules-inspector/src/app/pages/compare.vue
+++ b/packages/node-modules-inspector/src/app/pages/compare.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
+import { definePageMeta } from '#imports'
 import { computed, shallowReactive } from 'vue'
 import { selectedNode } from '~/state/current'
 import { filters } from '~/state/filters'

--- a/packages/node-modules-inspector/src/app/pages/compare.vue
+++ b/packages/node-modules-inspector/src/app/pages/compare.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
 import { computed, shallowReactive } from 'vue'
-import OffsettedContainer from '~/components/ui/OffsettedContainer.vue'
 import { selectedNode } from '~/state/current'
 import { filters } from '~/state/filters'
 import { payloads } from '~/state/payload'
@@ -20,6 +19,12 @@ const rootPackages = computed(() => {
   ]
     .map(x => payload.get(x))
     .filter(x => !!x)
+})
+
+const showGraph = computed(() => filters.state['compare-a']?.length || filters.state['compare-b']?.length)
+
+definePageMeta({
+  noOffset: showGraph,
 })
 
 function compare() {
@@ -43,54 +48,53 @@ function reset() {
 </script>
 
 <template>
-  <OffsettedContainer
-    v-if="!filters.state['compare-a']?.length || !filters.state['compare-b']?.length"
+  <div
+    v-if="!showGraph"
+    flex="~ col items-center justify-center gap-10" mt-10
   >
-    <div flex="~ col items-center justify-center gap-10" mt-10>
-      <div text-center>
-        <h1 text-2xl font-bold>
-          Select packages to compare
-        </h1>
-        <p op50>
-          Use the filters to select packages to compare
-        </p>
-      </div>
-      <div grid="~ cols-[1fr_max-content_1fr] gap-2">
-        <div>
-          <div text-yellow p2 text-center op75>
-            Compare Group A
-          </div>
-          <OptionPackageMultiSelectInput v-model:selected="selectedA" :excludes="selectedAll">
-            <template #icon>
-              <div i-ph-package-duotone text-lg text-yellow flex-none />
-            </template>
-          </OptionPackageMultiSelectInput>
-        </div>
-        <div p2 rounded op50 py13>
-          vs
-        </div>
-        <div>
-          <div text-purple p2 text-center op75>
-            Compare Group B
-          </div>
-          <OptionPackageMultiSelectInput v-model:selected="selectedB" :excludes="selectedAll">
-            <template #icon>
-              <div i-ph-package-duotone text-lg text-purple flex-none />
-            </template>
-          </OptionPackageMultiSelectInput>
-        </div>
-      </div>
-
-      <button
-        :disabled="!selectedA.size || !selectedB.size"
-        class="disabled:op25 disabled:pointer-events-none"
-        px5 py1 text-lg border="~ base rounded-full" hover="bg-active op100"
-        @click="compare"
-      >
-        Start Compare
-      </button>
+    <div text-center>
+      <h1 text-2xl font-bold>
+        Select packages to compare
+      </h1>
+      <p op50>
+        Use the filters to select packages to compare
+      </p>
     </div>
-  </OffsettedContainer>
+    <div grid="~ cols-[1fr_max-content_1fr] gap-2">
+      <div>
+        <div text-yellow p2 text-center op75>
+          Compare Group A
+        </div>
+        <OptionPackageMultiSelectInput v-model:selected="selectedA" :excludes="selectedAll">
+          <template #icon>
+            <div i-ph-package-duotone text-lg text-yellow flex-none />
+          </template>
+        </OptionPackageMultiSelectInput>
+      </div>
+      <div p2 rounded op50 py13>
+        vs
+      </div>
+      <div>
+        <div text-purple p2 text-center op75>
+          Compare Group B
+        </div>
+        <OptionPackageMultiSelectInput v-model:selected="selectedB" :excludes="selectedAll">
+          <template #icon>
+            <div i-ph-package-duotone text-lg text-purple flex-none />
+          </template>
+        </OptionPackageMultiSelectInput>
+      </div>
+    </div>
+
+    <button
+      :disabled="!selectedA.size || !selectedB.size"
+      class="disabled:op25 disabled:pointer-events-none"
+      px5 py1 text-lg border="~ base rounded-full" hover="bg-active op100"
+      @click="compare"
+    >
+      Start Compare
+    </button>
+  </div>
   <template v-else>
     <GraphCanvas
       :payload="payloads.filtered"

--- a/packages/node-modules-inspector/src/app/pages/graph.vue
+++ b/packages/node-modules-inspector/src/app/pages/graph.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
+import { definePageMeta } from '#imports'
 import { computed } from 'vue'
 import { filters } from '~/state/filters'
 import { payloads } from '~/state/payload'

--- a/packages/node-modules-inspector/src/app/pages/graph.vue
+++ b/packages/node-modules-inspector/src/app/pages/graph.vue
@@ -52,6 +52,10 @@ const rootPackages = computed(() => {
   return Array.from(root)
     .sort((a, b) => a.depth - b.depth || b.flatDependencies.size - a.flatDependencies.size)
 })
+
+definePageMeta({
+  noOffset: true,
+})
 </script>
 
 <template>

--- a/packages/node-modules-inspector/src/app/pages/grid.vue
+++ b/packages/node-modules-inspector/src/app/pages/grid.vue
@@ -23,19 +23,17 @@ const depthMap = computed(() => {
 </script>
 
 <template>
-  <UiOffsettedContainer>
-    <div flex="~ col gap-2">
-      <GridExpand
-        v-for="([depth, packages]) of depthMap" :key="depth"
-        :packages="packages"
-        :module-value="depth >= 4 ? false : true"
-      >
-        <template #title>
-          <span v-if="depth" op75>Depth {{ depth }}{{ depth === MAX_DEPTH ? '+' : '' }}</span>
-          <span v-else op75>Workspace Packages</span>
-          <DisplayNumberBadge :number="packages.length" rounded-full ml2 text-base />
-        </template>
-      </GridExpand>
-    </div>
-  </UiOffsettedContainer>
+  <div flex="~ col gap-2">
+    <GridExpand
+      v-for="([depth, packages]) of depthMap" :key="depth"
+      :packages="packages"
+      :module-value="depth >= 4 ? false : true"
+    >
+      <template #title>
+        <span v-if="depth" op75>Depth {{ depth }}{{ depth === MAX_DEPTH ? '+' : '' }}</span>
+        <span v-else op75>Workspace Packages</span>
+        <DisplayNumberBadge :number="packages.length" rounded-full ml2 text-base />
+      </template>
+    </GridExpand>
+  </div>
 </template>

--- a/packages/node-modules-inspector/src/app/pages/report.vue
+++ b/packages/node-modules-inspector/src/app/pages/report.vue
@@ -1,12 +1,10 @@
 <template>
-  <UiOffsettedContainer>
-    <ReportTransitiveDeps />
-    <ReportInstallSize />
-    <div grid="~ cols-2 gap-5">
-      <ReportEngines />
-      <ReportUsedBy />
-    </div>
-    <ReportPublishTime />
-    <ReportMultipleVersions />
-  </UiOffsettedContainer>
+  <ReportTransitiveDeps />
+  <ReportInstallSize />
+  <div grid="~ cols-2 gap-5">
+    <ReportEngines />
+    <ReportUsedBy />
+  </div>
+  <ReportPublishTime />
+  <ReportMultipleVersions />
 </template>

--- a/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
+++ b/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
@@ -38,7 +38,7 @@ async function run() {
 </script>
 
 <template>
-  <template v-if="!backend && !rawData">
+  <template v-if="!backend || !rawData">
     <div flex="~ col items-center gap-5" p10>
       <div min-h-120 flex="~ col gap-2 items-center justify-center" flex-auto>
         <UiTitle :has-error="!!error" :is-loading="isLoading" />

--- a/packages/node-modules-inspector/src/uno.config.ts
+++ b/packages/node-modules-inspector/src/uno.config.ts
@@ -20,7 +20,6 @@ export default defineConfig({
       'border-base': 'border-#8882',
 
       'bg-tooltip': 'bg-white:75 dark:bg-#111:75 backdrop-blur-8',
-      'bg-glass': 'bg-white:75 dark:bg-#111:75 backdrop-blur-5',
       'bg-code': 'bg-gray5:5',
 
       'bg-gradient-more': 'bg-gradient-to-t from-white via-white:80 to-white:0 dark:from-#111 dark:via-#111:80 dark:to-#111:0',
@@ -52,8 +51,11 @@ export default defineConfig({
       'color-scale-medium': 'text-amber:85! saturate-80',
       'color-scale-high': 'text-orange!',
       'color-scale-critical': 'text-red!',
+
+      'page-padding': 'pt-22 pl-112 pr-8 pb-8',
     },
     [/^badge-color-(\w+)$/, ([, color]) => `bg-${color}-400:20 dark:bg-${color}-400:10 text-${color}-700 dark:text-${color}-300 border-${color}-600:10 dark:border-${color}-300:10`],
+    [/^bg-glass(:\d+)?$/, ([, perc = ':75']) => `bg-white${perc} dark:bg-#111${perc} backdrop-blur-5`],
   ],
   theme: {
     colors: {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

When switching pages, it can take a moment for pages to load their data or populate the DOM. This PR adds a loading spinner when switching pages, but only after 200ms to prevent flashing the spinner on small dependency trees

![image](https://github.com/user-attachments/assets/c880376f-1e0a-47ac-b56c-df2771812f69)

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
