### PR TITLE
fix: ensure bg fills entire button in grid mode

### DIFF
--- a/packages/node-modules-inspector/src/app/components/grid/Item.vue
+++ b/packages/node-modules-inspector/src/app/components/grid/Item.vue
@@ -14,7 +14,7 @@ defineProps<{
     :pkg
     as="button"
     outer="border rounded-lg"
-    inner="flex flex-col gap-2 hover:bg-active p2 px3"
+    inner="flex flex-col gap-2 justify-center h-full hover:bg-active p2 px3"
     @click="selectedNode = pkg === selectedNode ? undefined : pkg"
   >
     <DisplayPackageSpec :pkg text-left />


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
Now:
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/398eb79b-dc68-41c0-91fb-2e6e24077774" />

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
Fixes #47 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
