### PR TITLE
fix: ensure update available before showing version bump tip

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/VersionWithUpdates.vue
+++ b/packages/node-modules-inspector/src/app/components/display/VersionWithUpdates.vue
@@ -14,6 +14,12 @@ const versionDiff = computed(() => {
     return ''
   return semver.diff(props.latest.version, props.version)
 })
+
+const updateAvailable = computed(() => {
+  if (!props.latest || !props.version)
+    return false
+  return semver.gt(props.latest.version, props.version)
+})
 </script>
 
 <template>
@@ -36,7 +42,7 @@ const versionDiff = computed(() => {
       <div v-else-if="latest.version === version">
         Up to date, last published at <DisplayDateBadge :time="latest.publishedAt" inline-block />
       </div>
-      <div v-else>
+      <div v-else-if="updateAvailable">
         New {{ versionDiff }} version <DisplayVersion inline-block text-primary :version="latest.version" /> published at <DisplayDateBadge inline-block rounded :time="latest.publishedAt" /> is available
       </div>
     </template>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR adds check before showing version bump tip.

As the fetched npm lastest meta info may be not up-to-date.

### Linked Issues

None.

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

None.

## Example

<img width="432" alt="Screenshot 2025-03-09 at 14 08 58" src="https://github.com/user-attachments/assets/31b515d4-ace9-4155-84b2-5fdc93b4cc80" />

