### PR TITLE
feat: handle private packages

### DIFF
--- a/packages/node-modules-inspector/src/shared/version-info.ts
+++ b/packages/node-modules-inspector/src/shared/version-info.ts
@@ -22,12 +22,13 @@ async function fetchBatch(
     promises.push(limit(async () => {
       try {
         const result = await getLatestVersionBatch(queue, { metadata: true })
-        for (const r of result) {
+        for (let i = 0; i < result.length; i++) {
+          const r = result[i]
           if (r.publishedAt) {
             onResult(r)
           }
           else {
-            missingSpecs.add(`${r.name}@${r.version}`)
+            missingSpecs.add('version' in r ? `${r.name}@${r.version}` : queue[i])
           }
         }
       }


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Improve handling of failed npm metadata fetch.

- [x] Enhance error handling.
- [ ] Use the current registry (possibly private) as a fallback to fetch metadata again.
- [ ] Improve return types of `getLatestVersionBatch`

### Linked Issues

resolves #65

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

I think `getLatestVersionBatch` of `fast-npm-meta` should also improve return types to indicate such failures (instead of only `ResolvedPackageVersion`). 🤔

https://github.com/antfu/fast-npm-meta/blob/4436925dea29e16bc2961f903a9c38a138116962/package/src/api.ts#L47
