### PR TITLE
chore: fix initial install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/packages/node-modules-inspector/package.json
+++ b/packages/node-modules-inspector/package.json
@@ -25,13 +25,13 @@
     "dist"
   ],
   "scripts": {
-    "dev": "pnpm run -r stub && nuxi dev --cwd=src .",
+    "dev": "pnpm run -r stub && cd src && nuxi dev",
     "stub": "unbuild --stub",
-    "build": "pnpm run wc:prepare && nuxi build --cwd=src . && unbuild",
+    "build": "pnpm run wc:prepare && nuxi build src && unbuild",
     "build:debug": "NUXT_DEBUG_BUILD=true pnpm run build",
     "start": "node ./bin.mjs",
     "prepack": "pnpm build",
-    "dev:prepare": "pnpm wc:prepare && nuxi prepare --cwd=src .",
+    "dev:prepare": "pnpm wc:prepare && nuxi prepare src",
     "wc:prepare": "rollup -c",
     "wc:build": "pnpm run wc:prepare && NMI_BACKEND=webcontainer nuxi build src && unbuild",
     "wc:dev": "pnpm run -r stub && pnpm run wc:prepare && cd src && NMI_BACKEND=webcontainer nuxi dev"

--- a/packages/node-modules-inspector/package.json
+++ b/packages/node-modules-inspector/package.json
@@ -25,13 +25,13 @@
     "dist"
   ],
   "scripts": {
-    "dev": "pnpm run -r stub && cd src && nuxi dev",
+    "dev": "pnpm run -r stub && nuxi dev --cwd=src .",
     "stub": "unbuild --stub",
-    "build": "pnpm run wc:prepare && nuxi build src && unbuild",
+    "build": "pnpm run wc:prepare && nuxi build --cwd=src . && unbuild",
     "build:debug": "NUXT_DEBUG_BUILD=true pnpm run build",
     "start": "node ./bin.mjs",
     "prepack": "pnpm build",
-    "dev:prepare": "nuxi prepare src",
+    "dev:prepare": "pnpm wc:prepare && nuxi prepare --cwd=src .",
     "wc:prepare": "rollup -c",
     "wc:build": "pnpm run wc:prepare && NMI_BACKEND=webcontainer nuxi build src && unbuild",
     "wc:dev": "pnpm run -r stub && pnpm run wc:prepare && cd src && NMI_BACKEND=webcontainer nuxi dev"

--- a/packages/node-modules-inspector/package.json
+++ b/packages/node-modules-inspector/package.json
@@ -31,7 +31,7 @@
     "build:debug": "NUXT_DEBUG_BUILD=true pnpm run build",
     "start": "node ./bin.mjs",
     "prepack": "pnpm build",
-    "dev:prepare": "pnpm wc:prepare && nuxi prepare src",
+    "dev:prepare": "nuxi prepare src && pnpm wc:prepare",
     "wc:prepare": "rollup -c",
     "wc:build": "pnpm run wc:prepare && NMI_BACKEND=webcontainer nuxi build src && unbuild",
     "wc:dev": "pnpm run -r stub && pnpm run wc:prepare && cd src && NMI_BACKEND=webcontainer nuxi dev"

--- a/packages/node-modules-inspector/src/app/modules/webcontainer.ts
+++ b/packages/node-modules-inspector/src/app/modules/webcontainer.ts
@@ -6,13 +6,15 @@ export default defineNuxtModule({
   meta: {
     name: 'webcontainer-setup',
   },
-  setup() {
-    addTemplate({
-      filename: 'webcontainer-server-code',
-      getContents: async () => {
-        const content = await fs.readFile(fileURLToPath(new URL('../../../runtime/webcontainer-server.mjs', import.meta.url)), 'utf-8')
-        return `export const WEBCONTAINER_SERVER_CODE = ${JSON.stringify(content)}`
-      },
-    })
+  setup(_, nuxt) {
+    if (!nuxt.options._prepare) {
+      addTemplate({
+        filename: 'webcontainer-server-code',
+        getContents: async () => {
+          const content = await fs.readFile(fileURLToPath(new URL('../../../runtime/webcontainer-server.mjs', import.meta.url)), 'utf-8')
+          return `export const WEBCONTAINER_SERVER_CODE = ${JSON.stringify(content)}`
+        },
+      })
+    }
   },
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When installing dependencies, there is an error since the `node-modules-inspector/runtime/webcontainer-server.mjs` module is built using Rollup. This PR includes the build when preparing the `node-modules-inspector` package:
```json
"dev:prepare": "pnpm wc:prepare && nuxi prepare src",
```

This PR includes  `.gitignore`  at root to avoid changing `CRLF` when regenerating files.

Looks like we have a dead lock (on fresh install/build), we cannot run Rollup since it is using Nuxt tsconfig file, and cannot run Nuxt prepare script since it depends on the module built by Rollup: we need a custom tsconfig file for Rollup, `server.ts` module doesn't have any dependency on Nuxt.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

![image](https://github.com/user-attachments/assets/9318f5d1-435f-4a8a-96a6-d231ad991ef5)
_Install error_
