### PR TITLE
chore: fix typecheck script

### DIFF
--- a/packages/node-modules-inspector/src/app/modules/webcontainer.ts
+++ b/packages/node-modules-inspector/src/app/modules/webcontainer.ts
@@ -6,15 +6,21 @@ export default defineNuxtModule({
   meta: {
     name: 'webcontainer-setup',
   },
-  setup(_, nuxt) {
-    if (!nuxt.options._prepare) {
-      addTemplate({
-        filename: 'webcontainer-server-code',
-        getContents: async () => {
+  setup() {
+    addTemplate({
+      filename: 'webcontainer-server-code',
+      getContents: async ({ nuxt }) => {
+        try {
           const content = await fs.readFile(fileURLToPath(new URL('../../../runtime/webcontainer-server.mjs', import.meta.url)), 'utf-8')
           return `export const WEBCONTAINER_SERVER_CODE = ${JSON.stringify(content)}`
-        },
-      })
-    }
+        }
+        catch (e) {
+          if (nuxt.options._prepare) {
+            return `export const WEBCONTAINER_SERVER_CODE = ''`
+          }
+          throw e
+        }
+      },
+    })
   },
 })


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR creates an empty `webcontainer-server-code` template when running Nuxt `prepare` script otherwise rethrow the error  to allow run `typecheckscript` at root after runing `prepare` script.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
