### PR TITLE
chore: fix start dev server on Windows

### DIFF
--- a/packages/node-modules-inspector/package.json
+++ b/packages/node-modules-inspector/package.json
@@ -25,7 +25,7 @@
     "dist"
   ],
   "scripts": {
-    "dev": "pnpm run -r stub && cd src && nuxi dev",
+    "dev": "pnpm run -r stub && nuxi dev src",
     "stub": "unbuild --stub",
     "build": "pnpm run wc:prepare && nuxi build src && unbuild",
     "build:debug": "NUXT_DEBUG_BUILD=true pnpm run build",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Cannot use `cd src`  when starting the dev server on Windows:

![image](https://github.com/user-attachments/assets/afea8a61-d651-4088-a70b-4b7b936fdeba)


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
