### PR TITLE
feat: support legacy license/licenses format

### DIFF
--- a/packages/node-modules-inspector/src/app/components/option/PackageSelect.vue
+++ b/packages/node-modules-inspector/src/app/components/option/PackageSelect.vue
@@ -33,6 +33,7 @@ const fuse = computed(() => new Fuse(props.payload.packages, {
     'resolved.packageJson.funding',
     'resolved.packageJson.fundings',
     'resolved.packageJson.license',
+    'resolved.packageJson.license.type',
   ],
 }))
 

--- a/packages/node-modules-inspector/src/app/components/panel/Overview.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/Overview.vue
@@ -5,7 +5,7 @@ import { getBackend } from '../../backends'
 import { rawPayload } from '../../state/data'
 import { getDeprecatedInfo, payloads, totalWorkspaceSize } from '../../state/payload'
 import { settings } from '../../state/settings'
-import { getFundings } from '../../utils/package-json'
+import { getFundings, getPackageData } from '../../utils/package-json'
 
 const backend = getBackend()
 
@@ -24,7 +24,7 @@ const fundingCount = computed(() => payloads.avaliable.packages
 const licensesCount = computed(() => {
   const set = new Set<string>()
   payloads.avaliable.packages.forEach((p) => {
-    set.add(p.resolved.packageJson.license || '<Unspecified>')
+    set.add(getPackageData(p).license || '<Unspecified>')
   })
   return set.size
 })

--- a/packages/node-modules-inspector/src/app/components/report/Licenses.vue
+++ b/packages/node-modules-inspector/src/app/components/report/Licenses.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
+import { getPackageData } from '@/utils/package-json'
 import { computed, ref } from 'vue'
 import { selectedNode } from '../../state/current'
 import { payloads } from '../../state/payload'
@@ -21,7 +22,7 @@ const licensesGroup = computed(() => {
   for (const pkg of payloads.filtered.packages) {
     if (pkg.workspace)
       continue
-    const key = pkg.resolved.packageJson.license || '<Unspecified>'
+    const key = getPackageData(pkg).license || '<Unspecified>'
     if (!group.has(key))
       group.set(key, [])
     group.get(key)!.push(pkg)
@@ -120,7 +121,7 @@ const filteredResult = computed(() => {
               target="_blank"
               badge-color-gray px2 rounded-full w-max text-sm h-max
             >
-              {{ pkg.resolved.packageJson.license }}
+              {{ getPackageData(pkg).license }}
             </a>
             <div w-max>
               <DisplaySourceTypeBadge :pkg mode="both" />

--- a/packages/node-modules-inspector/src/app/pages/grid/[...grid].vue
+++ b/packages/node-modules-inspector/src/app/pages/grid/[...grid].vue
@@ -4,7 +4,7 @@ import { useRoute } from '#app/composables/router'
 import SafeImage from '@/components/display/SafeImage.vue'
 import { computed } from 'vue'
 import { payloads } from '../../state/payload'
-import { getAuthors, getRepository } from '../../utils/package-json'
+import { getAuthors, getPackageData, getRepository } from '../../utils/package-json'
 
 const params = useRoute().params as Record<string, string>
 const tab = computed<'depth' | 'clusters' | 'module-type' | 'authors' | 'licenses' | 'github'>(() => params.grid[0] as any || 'depth')
@@ -84,7 +84,7 @@ const groups = computed<Group[]>(() => {
   else if (tab.value === 'licenses') {
     const map = new Map<string, PackageNode[]>()
     for (const pkg of payloads.filtered.packages) {
-      const license = pkg.resolved.packageJson.license || '<Unspecified>'
+      const license = getPackageData(pkg).license || '<Unspecified>'
       if (!map.has(license))
         map.set(license, [])
       map.get(license)?.push(pkg)

--- a/packages/node-modules-inspector/src/app/state/filters.ts
+++ b/packages/node-modules-inspector/src/app/state/filters.ts
@@ -7,7 +7,7 @@ import { constructPackageFilters } from 'node-modules-tools/utils'
 import { computed, reactive, toRaw } from 'vue'
 import { FILTERS_SCHEMA } from '../../shared/filters'
 import { getModuleType } from '../utils/module-type'
-import { getAuthors } from '../utils/package-json'
+import { getAuthors, getPackageData } from '../utils/package-json'
 import { parseSearch } from '../utils/search-parser'
 import { rawPayload } from './data'
 
@@ -110,10 +110,11 @@ export const filterSelectPredicate = computed(() => {
         }
       }
       if (parsed.license?.length) {
-        if (!pkg.resolved.packageJson.license)
+        const license = getPackageData(pkg).license
+        if (!license)
           return false
         for (const re of parsed.license) {
-          if (!re.test(pkg.resolved.packageJson.license))
+          if (!re.test(license))
             return false
         }
       }

--- a/packages/node-modules-inspector/src/app/utils/package-json.ts
+++ b/packages/node-modules-inspector/src/app/utils/package-json.ts
@@ -1,5 +1,5 @@
 import type { PackageNode } from 'node-modules-tools'
-import { normalizePkgAuthors, normalizePkgFundings, normalizePkgRepository } from 'node-modules-tools/utils'
+import { normalizePkgAuthors, normalizePkgFundings, normalizePkgLicense, normalizePkgRepository } from 'node-modules-tools/utils'
 
 function weakCachedFunction<T extends WeakKey, R>(fn: (arg: T) => R): (arg: T) => R {
   const cache = new WeakMap<T, R>()
@@ -16,10 +16,11 @@ function weakCachedFunction<T extends WeakKey, R>(fn: (arg: T) => R): (arg: T) =
 export const getAuthors = weakCachedFunction((pkg: PackageNode) => normalizePkgAuthors(pkg.resolved.packageJson))
 export const getRepository = weakCachedFunction((pkg: PackageNode) => normalizePkgRepository(pkg.resolved.packageJson))
 export const getFundings = weakCachedFunction((pkg: PackageNode) => normalizePkgFundings(pkg.resolved.packageJson))
+export const getLicense = weakCachedFunction((pkg: PackageNode) => normalizePkgLicense(pkg.resolved.packageJson))
 
 export const getPackageData = weakCachedFunction((pkg: PackageNode) => {
   return {
-    license: pkg.resolved.packageJson.license,
+    license: getLicense(pkg),
     homepage: pkg.resolved.packageJson.homepage,
     engines: pkg.resolved.packageJson.engines,
     authors: getAuthors(pkg),

--- a/packages/node-modules-tools/src/resolve.ts
+++ b/packages/node-modules-tools/src/resolve.ts
@@ -25,6 +25,7 @@ export const PACKAGE_JSON_KEYS = [
   'imports',
   'keywords',
   'license',
+  'licenses',
   'main',
   'module',
   'name',

--- a/packages/node-modules-tools/src/utils/package-json.test.ts
+++ b/packages/node-modules-tools/src/utils/package-json.test.ts
@@ -1,0 +1,16 @@
+import type { PackageJson } from 'pkg-types'
+import { describe, expect, it } from 'vitest'
+import { normalizePkgLicense } from './package-json'
+
+describe('normalize', () => {
+  describe('normalizePkgLicense', () => {
+    it('should parse legacy object format', () => {
+      expect(normalizePkgLicense({ license: { type: 'MIT', url: 'dontcare' } } as unknown as PackageJson)).toMatchInlineSnapshot(`"MIT"`)
+    })
+    it('should parse legacy array format', () => {
+      expect(normalizePkgLicense({ license: [] } as unknown as PackageJson)).toMatchInlineSnapshot(`undefined`)
+      expect(normalizePkgLicense({ license: [{ type: 'MIT', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"MIT"`)
+      expect(normalizePkgLicense({ license: [{ type: 'MIT', url: 'dontcare' }, { type: 'ISC', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"(MIT OR ISC)"`)
+    })
+  })
+})

--- a/packages/node-modules-tools/src/utils/package-json.test.ts
+++ b/packages/node-modules-tools/src/utils/package-json.test.ts
@@ -8,9 +8,9 @@ describe('normalize', () => {
       expect(normalizePkgLicense({ license: { type: 'MIT', url: 'dontcare' } } as unknown as PackageJson)).toMatchInlineSnapshot(`"MIT"`)
     })
     it('should parse legacy array format', () => {
-      expect(normalizePkgLicense({ license: [] } as unknown as PackageJson)).toMatchInlineSnapshot(`undefined`)
-      expect(normalizePkgLicense({ license: [{ type: 'MIT', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"MIT"`)
-      expect(normalizePkgLicense({ license: [{ type: 'MIT', url: 'dontcare' }, { type: 'ISC', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"(MIT OR ISC)"`)
+      expect(normalizePkgLicense({ licenses: [] } as unknown as PackageJson)).toMatchInlineSnapshot(`undefined`)
+      expect(normalizePkgLicense({ licenses: [{ type: 'MIT', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"MIT"`)
+      expect(normalizePkgLicense({ licenses: [{ type: 'MIT', url: 'dontcare' }, { type: 'ISC', url: 'dontcare' }] } as unknown as PackageJson)).toMatchInlineSnapshot(`"(MIT OR ISC)"`)
     })
   })
 })

--- a/packages/node-modules-tools/src/utils/package-json.ts
+++ b/packages/node-modules-tools/src/utils/package-json.ts
@@ -66,21 +66,19 @@ export function normalizePkgLicense(json: PackageJson): ParsedLicense | undefine
     type: string
     url?: string
   }
-  const _json = json as (PackageJson | { license?: LegacyLicense | LegacyLicense[] })
+
+  const _json = json as (PackageJson | { license?: LegacyLicense, licenses?: LegacyLicense[] })
   switch (typeof _json.license) {
     case 'string':
       return _json.license
     case 'object':
-      if (!Array.isArray(_json.license)) {
-        return _json.license.type
-      }
-      if (!_json.license.length)
-        return
-      if (_json.license.length === 1) {
-        return _json.license[0].type
-      }
-      return `(${_json.license.map(l => l.type).join(' OR ')})`
-    default:
+      return _json.license.type
+  }
+
+  if (Array.isArray(_json.licenses)) {
+    if (!_json.licenses.length)
+      return
+    return `(${_json.licenses.map(l => l.type).join(' OR ')})`
   }
 }
 

--- a/packages/node-modules-tools/src/utils/package-json.ts
+++ b/packages/node-modules-tools/src/utils/package-json.ts
@@ -66,7 +66,6 @@ export function normalizePkgLicense(json: PackageJson): ParsedLicense | undefine
     type: string
     url?: string
   }
-
   const _json = json as (PackageJson | { license?: LegacyLicense, licenses?: LegacyLicense[] })
   switch (typeof _json.license) {
     case 'string':
@@ -78,6 +77,9 @@ export function normalizePkgLicense(json: PackageJson): ParsedLicense | undefine
   if (Array.isArray(_json.licenses)) {
     if (!_json.licenses.length)
       return
+    if (_json.licenses.length === 1) {
+      return _json.licenses[0].type
+    }
     return `(${_json.licenses.map(l => l.type).join(' OR ')})`
   }
 }

--- a/packages/node-modules-tools/src/utils/package-json.ts
+++ b/packages/node-modules-tools/src/utils/package-json.ts
@@ -59,6 +59,31 @@ export function parseFunding(funding: NormalizedFunding): ParsedFunding {
   }
 }
 
+export type ParsedLicense = string
+
+export function normalizePkgLicense(json: PackageJson): ParsedLicense | undefined {
+  interface LegacyLicense {
+    type: string
+    url?: string
+  }
+  const _json = json as (PackageJson | { license?: LegacyLicense | LegacyLicense[] })
+  switch (typeof _json.license) {
+    case 'string':
+      return _json.license
+    case 'object':
+      if (!Array.isArray(_json.license)) {
+        return _json.license.type
+      }
+      if (!_json.license.length)
+        return
+      if (_json.license.length === 1) {
+        return _json.license[0].type
+      }
+      return `(${_json.license.map(l => l.type).join(' OR ')})`
+    default:
+  }
+}
+
 export function normalizePkgFundings(json: PackageJson): ParsedFunding[] | undefined {
   type RawFunding = string | NormalizedFunding
   const rawFunding: RawFunding | RawFunding[] | undefined = json.funding


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR normalises pkg license fields to support legacy formats.

Unfortunately, the `PackageJson['license']` type only supports strings. So I had to cast the type in the normalize fn. Maybe we can do this a bit cleaner. Not sure if the type should be updated in general. this legacy licence format is just an edgecase.


## Examples:

Dep with object license

```json
"license":{
    "type":"MIT",
    "url":"http://github.com/.../LICENSE"
  }
```
short:  https://deploy-preview-82--node-modules-inspector.netlify.app/grid#selected=short@2.6.0&install=short
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
config-chain: https://deploy-preview-82--node-modules-inspector.netlify.app/grid#selected=config-chain@1.1.13&install=config-chain


Dep with multiple licenes as `licenses`

```json
    "licenses": [
        {
            "type": "MIT",
            "url": "..."
        },
        {
            "type": "GPL-2.0",
            "url": "..."
        }
    ],
```

@kflorence/jquery-wizard https://deploy-preview-82--node-modules-inspector.netlify.app/grid#selected=@kflorence/jquery-wizard@1.1.3&install=@kflorence/jquery-wizard


Dep with single licenes as `licenses`

```json
  "licenses": [
    {
      "type": "MIT",
      "url": "..."
    }
  ],
```

readium-js: https://deploy-preview-82--node-modules-inspector.netlify.app/grid#selected=readium-js@0.0.0&install=readium-js

### Linked Issues

fix https://github.com/antfu/node-modules-inspector/issues/81

### Additional context

https://docs.npmjs.com/cli/v11/configuring-npm/package-json#license

<!-- e.g. is there anything you'd like reviewers to focus on? -->

We should also think about how to handle/filter licenses with `OR` 😅 
