### PR TITLE
feat: enhance input handling with composition support

### DIFF
--- a/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
+++ b/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, shallowRef } from 'vue'
+import { onMounted, ref, shallowRef } from 'vue'
 import { backend } from '../backends'
 import MainEntry from '../entries/main.vue'
 import { fetchData, rawPayload } from '../state/data'
@@ -11,6 +11,14 @@ showTerminal.value = true
 const input = shallowRef(query.install?.trim().replace(/\+/g, ' ') || '')
 const error = shallowRef<any>()
 const isLoading = shallowRef(false)
+const isComposing = ref(false)
+
+function handleCompositionEnd(_event: CompositionEvent) {
+  isComposing.value = false
+  if (input.value) {
+    setTimeout(() => run(), 0)
+  }
+}
 
 onMounted(() => {
   getContainer()
@@ -57,7 +65,9 @@ async function run() {
             :disabled="isLoading"
             w-120 px1 py2 font-mono bg-transparent outline-none
             placeholder-gray:40
-            @keydown.enter="run"
+            @keydown.enter="!isComposing && run()"
+            @compositionstart="isComposing = true"
+            @compositionend="handleCompositionEnd"
           >
         </label>
         <div text-center transition duration-500 italic :class="input ? 'op35' : 'op0'">

--- a/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
+++ b/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
@@ -16,7 +16,7 @@ const isComposing = ref(false)
 function handleCompositionEnd(_event: CompositionEvent) {
   isComposing.value = false
   if (input.value) {
-    setTimeout(() => run(), 0)
+    run()
   }
 }
 

--- a/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
+++ b/packages/node-modules-inspector/src/app/webcontainer/Landing.vue
@@ -15,18 +15,20 @@ const isComposing = ref(false)
 
 function handleCompositionEnd(_event: CompositionEvent) {
   isComposing.value = false
-  if (input.value) {
-    run()
-  }
+  run()
 }
 
 onMounted(() => {
   getContainer()
-  if (input.value)
-    run()
+  run()
 })
 
 async function run() {
+  if (!input.value?.trim()) {
+    input.value = ''
+    return
+  }
+
   isLoading.value = true
   query.install = input.value.replace(/\s+/g, '+')
   try {


### PR DESCRIPTION
### Description

Fix an issue where package names entered using IME (Input Method Editor) couldn't be installed when pressing Enter. When using IME input methods (like Chinese input), if a user entered a package name (such as "antd") and pressed Enter, the system would attempt to install an empty package because the `@keydown.enter` event was triggered while the input was still in composition state, before the `v-model` value was updated.

This PR resolves the issue by implementing proper composition event handling:
1. Add an `isComposing` state to track IME input status
2. Prevent Enter key from triggering installation during composition
3. Ensure v-model is fully updated after composition ends before executing installation

### Linked Issues

none

### Additional context

**Screenshot**
![inspector-bug](https://github.com/user-attachments/assets/e052c1d3-2b1c-4804-8b2b-23a91f6b16b2)


This issue only occurs when using IME-based languages like Chinese, Japanese, etc. It doesn't affect direct keyboard input in English. The fix ensures proper event capture during IME composition, making the experience consistent for all users regardless of their input method.
