### PR TITLE
fix: keep location hash when switching grid tabs

### DIFF
--- a/packages/node-modules-inspector/src/app/pages/grid/[...grid].vue
+++ b/packages/node-modules-inspector/src/app/pages/grid/[...grid].vue
@@ -10,6 +10,8 @@ import { getAuthors, getPackageData, getRepository } from '../../utils/package-j
 const params = useRoute().params as Record<string, string>
 const tab = computed<'depth' | 'clusters' | 'module-type' | 'authors' | 'licenses' | 'github'>(() => params.grid[0] as any || 'depth')
 
+const location = window.location
+
 const MAX_DEPTH = 5
 
 interface Group {
@@ -147,23 +149,23 @@ const groups = computed<Group[]>(() => {
       <div op-fade>
         Group by
       </div>
-      <NuxtLink btn-action as="button" to="/grid/depth" active-class="text-primary bg-primary:5">
+      <NuxtLink btn-action as="button" :to="{ path: '/grid/depth', hash: location.hash }" active-class="text-primary bg-primary:5">
         <div i-ph-stack-simple-duotone />
         Depth
       </NuxtLink>
-      <NuxtLink btn-action as="button" to="/grid/module-type" active-class="text-primary bg-primary:5">
+      <NuxtLink btn-action as="button" :to="{ path: '/grid/module-type', hash: location.hash }" active-class="text-primary bg-primary:5">
         <div i-ph-file-code-duotone />
         Module Type
       </NuxtLink>
-      <NuxtLink btn-action as="button" to="/grid/clusters" active-class="text-primary bg-primary:5">
+      <NuxtLink btn-action as="button" :to="{ path: '/grid/clusters', hash: location.hash }" active-class="text-primary bg-primary:5">
         <div i-ph-exclude-duotone />
         Clusters
       </NuxtLink>
-      <NuxtLink btn-action as="button" to="/grid/authors" active-class="text-primary bg-primary:5">
+      <NuxtLink btn-action as="button" :to="{ path: '/grid/authors', hash: location.hash }" active-class="text-primary bg-primary:5">
         <div i-ph-user-circle-duotone />
         Authors
       </NuxtLink>
-      <NuxtLink btn-action as="button" to="/grid/licenses" active-class="text-primary bg-primary:5">
+      <NuxtLink btn-action as="button" :to="{ path: '/grid/licenses', hash: location.hash }" active-class="text-primary bg-primary:5">
         <div i-ph-file-text-duotone />
         License
       </NuxtLink>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

while looking into #101 I saw that the hash is lost when routing the grid tabs

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

maybe we should update the hashes with vue/nuxt router. I will test tomorrow. This should fix it for now. (Copied from charts)

<!-- e.g. is there anything you'd like reviewers to focus on? -->
