### PR TITLE
fix: adjust Ctrl + mouse wheel zoom direction in the graph view

### DIFF
--- a/packages/node-modules-inspector/src/app/composables/zoomElement.ts
+++ b/packages/node-modules-inspector/src/app/composables/zoomElement.ts
@@ -48,7 +48,7 @@ export function useZoomElement(
     event.preventDefault()
 
     const zoomFactor = 0.2
-    zoom(event.deltaY > 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+    zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
   }
 
   function zoomIn(factor = 0.2) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Adjusted the zoom direction of Ctrl+mouse wheel in the chart view to match the browser behavior. 
Now, Ctrl+mouse wheel up will zoom in, and Ctrl+mouse wheel down will zoom out.
### Linked Issues

fixes #115


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
