### PR TITLE
fix: add workaround for undefined package names from node-modules-tools

### DIFF
--- a/packages/node-modules-inspector/src/shared/version-info.ts
+++ b/packages/node-modules-inspector/src/shared/version-info.ts
@@ -100,7 +100,7 @@ export async function getPackagesNpmMeta(
 }
 
 export async function getPackagesNpmMetaLatest(
-  packages: string[],
+  packages: (string | undefined)[],
   options: ListPackagesNpmMetaLatestOptions,
 ): Promise<Map<string, NpmMetaLatest | null>> {
   const { storageNpmMetaLatest: storage } = options
@@ -108,11 +108,15 @@ export async function getPackagesNpmMetaLatest(
   const map = new Map<string, NpmMetaLatest>()
 
   packages.forEach((p) => {
+    if (!p)
+      throw new Error('Package name cannot be empty')
     if (p.split(/@/g).length >= 3)
       throw new Error(`Invalid package name: ${p}`)
   })
 
   await Promise.all(packages.map(async (p) => {
+    if (!p)
+      return
     const meta = await storage.getItem(p)
     if (!meta)
       return
@@ -123,7 +127,7 @@ export async function getPackagesNpmMetaLatest(
     map.set(p, meta)
   }))
 
-  const unknown = packages.filter(p => !map.has(p))
+  const unknown = packages.filter(p => p && !map.has(p))
 
   const {
     missing,


### PR DESCRIPTION

### Description

If `node-modules-tools` finds a corrupted (e.g. empty) package in node_modules, PackageNode will have several properties undefined, including `name`. This results in `packages` having some values `undefined`, unlike the types may suggest.

### Linked Issues

Fixes #117

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
