### PR TITLE
fix: filter leftover empty directories returned by npm query in node-modules-tools

### DIFF
--- a/packages/node-modules-tools/src/agents/npm/list.ts
+++ b/packages/node-modules-tools/src/agents/npm/list.ts
@@ -67,7 +67,15 @@ async function queryDependencies(options: ListPackageDependenciesOptions, query:
   if (!Array.isArray(json))
     throw new Error(`Failed to parse \`npm query\` output, expected an array but got: ${String(json)}`)
 
-  return json
+  return json.filter((pkg): pkg is NpmPackageNode => {
+    return (
+      pkg
+      && typeof pkg === 'object'
+      && typeof pkg._id === 'string'
+      && typeof pkg.name === 'string'
+      && typeof pkg.version === 'string'
+    )
+  })
 }
 
 export async function listPackageDependencies(

--- a/packages/node-modules-tools/test/npm/fixtures/broken-install/.gitignore
+++ b/packages/node-modules-tools/test/npm/fixtures/broken-install/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/packages/node-modules-tools/test/npm/fixtures/broken-install/node_modules/valid-package/package.json
+++ b/packages/node-modules-tools/test/npm/fixtures/broken-install/node_modules/valid-package/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "valid-package",
+  "version": "1.0.0",
+  "packageManager": "npm@0.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "keywords": [],
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/packages/node-modules-tools/test/npm/fixtures/broken-install/package.json
+++ b/packages/node-modules-tools/test/npm/fixtures/broken-install/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "root-package",
+  "version": "1.0.0",
+  "packageManager": "npm@0.0.0",
+  "description": "",
+  "author": "",
+  "license": "ISC",
+  "keywords": [],
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  }
+}

--- a/packages/node-modules-tools/test/npm/list.test.ts
+++ b/packages/node-modules-tools/test/npm/list.test.ts
@@ -14,4 +14,17 @@ describe('listNpmPackageDependencies', () => {
     expect(list.packageManager).toBe('npm')
     expect(list.packages.size).toBe(2)
   })
+
+  it('ignores leftover directories npm fails to clean up', async () => {
+    const list = await listPackageDependencies({
+      cwd: fileURLToPath(new URL('./fixtures/broken-install', import.meta.url)),
+      depth: 25,
+      monorepo: true,
+      workspace: false,
+    })
+
+    expect(list.packageManager).toBe('npm')
+    expect(list.packages.size).toBe(2)
+    expect(Array.from(list.packages.values()).every(i => i.name)).toBe(true)
+  })
 })


### PR DESCRIPTION
### Description

`npm query` appears to be returning broken entries if it finds an empty directory in node_modules somewhere. This filters trash out, so that the return type can be actually trusted.

### Linked Issues

Fixes #117

### Additional context

A "one-liner" version of this fix is in #118. Feel free to choose which one you like best.
