### PR TITLE
fix analyze package module type

### DIFF
--- a/packages/node-modules-inspector/src/app/composables/zoomElement.ts
+++ b/packages/node-modules-inspector/src/app/composables/zoomElement.ts
@@ -48,7 +48,7 @@ export function useZoomElement(
     event.preventDefault()
 
     const zoomFactor = 0.2
-    zoom(event.deltaY > 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
+    zoom(event.deltaY < 0 ? zoomFactor : zoomFactor * -1, event.clientX, event.clientY)
   }
 
   function zoomIn(factor = 0.2) {

--- a/packages/node-modules-tools/src/analyze-esm.ts
+++ b/packages/node-modules-tools/src/analyze-esm.ts
@@ -20,14 +20,8 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   }
 
   // Check exports map.
-  if (exports && typeof exports === 'object') {
-    for (const exportId in exports) {
-      if (Object.hasOwn(exports, exportId) && typeof exportId === 'string') {
-        // @ts-expect-error: indexing on object is fine.
-        const value = /** @type {unknown} */ (exports[exportId])
-        analyzeThing(value, `${pkgJson.name}#exports`)
-      }
-    }
+  if (exports) {
+    analyzeThing(exports, `${pkgJson.name}#exports`)
   }
 
   // Explicit `commonjs` set, with a explicit `import` or `.mjs` too.

--- a/packages/node-modules-tools/test/module-type.test.ts
+++ b/packages/node-modules-tools/test/module-type.test.ts
@@ -25,6 +25,9 @@ it('types only', async () => {
 it('dual', async () => {
   expect(analyzePackageModuleType(await getPackageJsonPath('h3')))
     .toEqual('dual')
+
+  expect(analyzePackageModuleType(await getPackageJsonPath('rollup-plugin-esbuild')))
+    .toEqual('dual')
 })
 
 it('cjs', async () => {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR optimizes the package module type analysis to correctly identify ESM-only packages, addressing issues with packages like rollup-plugin-esbuild.
Ported  from: https://github.com/wooorm/npm-esm-vs-cjs/blob/main/script/crawl.js
### Linked Issues
fixes #24 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
