### PR TITLE
fix: fix missing public assets

### DIFF
--- a/packages/node-modules-inspector/src/nuxt.config.ts
+++ b/packages/node-modules-inspector/src/nuxt.config.ts
@@ -35,6 +35,10 @@ export default defineNuxtConfig({
   logLevel: 'verbose',
   srcDir: 'app',
 
+  dir: {
+    public: './app/public',
+  },
+
   eslint: {
     config: {
       standalone: false,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This PR fixes public assets missing as https://github.com/antfu/node-modules-inspector/commit/16e01545e5395f1fd7e67faed4e9c9387716619f bumped nuxt to v4 and nuxt v4 use `public` dir from project root by default.

### Linked Issues

None

### Additional context

Maybe tweak the project structure to follow nuxt v4 suggestion.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
