### PR TITLE
feat: add ProvenanceBadge component and use it in grid view

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/PackageSpec.vue
+++ b/packages/node-modules-inspector/src/app/components/display/PackageSpec.vue
@@ -11,7 +11,7 @@ const deprecation = computed(() => getDeprecatedInfo(props.pkg))
 </script>
 
 <template>
-  <span>
+  <div flex gap-2 items-center>
     <span
       v-if="pkg.workspace"
       h-1em w-1.5em relative of-visible inline-block
@@ -21,18 +21,23 @@ const deprecation = computed(() => getDeprecatedInfo(props.pkg))
         i-catppuccin-folder-packages-open icon-catppuccin mr2 absolute left-0 top-0
       />
     </span>
-    <DisplayPackageName
-      v-tooltip="deprecation?.latest ? `Package is deprecated: ${deprecation.latest}` : undefined"
-      :name="props.pkg.name"
+    <span>
+      <DisplayPackageName
+        v-tooltip="deprecation?.latest ? `Package is deprecated: ${deprecation.latest}` : undefined"
+        :name="props.pkg.name"
+        :pkg="props.pkg"
+        :class="!deprecation?.latest ? undefined : deprecation?.type === 'future' ? 'text-orange line-through' : 'text-red line-through'"
+      />
+      <DisplayVersion
+        v-tooltip="deprecation?.current ? `Current version is deprecated: ${deprecation.current}` : undefined"
+        op-fade
+        :version="props.pkg.version"
+        prefix="@"
+        :class="{ 'text-red line-through': deprecation?.current }"
+      />
+    </span>
+    <DisplayProvenanceBadge
       :pkg="props.pkg"
-      :class="!deprecation?.latest ? undefined : deprecation?.type === 'future' ? 'text-orange line-through' : 'text-red line-through'"
     />
-    <DisplayVersion
-      v-tooltip="deprecation?.current ? `Current version is deprecated: ${deprecation.current}` : undefined"
-      op-fade
-      :version="props.pkg.version"
-      prefix="@"
-      :class="{ 'text-red line-through': deprecation?.current }"
-    />
-  </span>
+  </div>
 </template>

--- a/packages/node-modules-inspector/src/app/components/display/ProvenanceBadge.vue
+++ b/packages/node-modules-inspector/src/app/components/display/ProvenanceBadge.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { PackageNode } from 'node-modules-tools'
+import { Tooltip } from 'floating-vue'
+import { computed } from 'vue'
+import { getNpmMeta } from '../../state/payload'
+
+const props = defineProps<{
+  pkg: PackageNode
+}>()
+const meta = computed(() => getNpmMeta(props.pkg))
+</script>
+
+<template>
+  <Tooltip v-if="meta?.provenance">
+    <div i-ph:circle-wavy-check-duotone text-primary-400 text-sm />
+    <template #popper>
+      This package is built and signed
+      {{ meta.provenance === 'trustedPublisher' ? 'by trusted publisher' : 'with provenance' }}
+    </template>
+  </Tooltip>
+</template>

--- a/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
 import { useRouter } from '#app/composables/router'
-import { Tooltip, Menu as VMenu } from 'floating-vue'
+import { Menu as VMenu } from 'floating-vue'
 import { computed, nextTick, watch } from 'vue'
 import { getBackend } from '../../backends'
 import { selectedNode } from '../../state/current'
@@ -216,13 +216,9 @@ const thirdPartyServices = computed(() => {
           :class="deprecation?.latest ? deprecation.type === 'future' ? 'text-orange line-through' : 'text-red line-through' : ''"
         />
 
-        <Tooltip v-if="meta?.provenance">
-          <div i-ph:circle-wavy-check-duotone text-primary-400 text-sm />
-          <template #popper>
-            This package is built and signed
-            {{ meta.provenance === 'trustedPublisher' ? 'by trusted publisher' : 'with provenance' }}
-          </template>
-        </Tooltip>
+        <DisplayProvenanceBadge
+          :pkg="pkg"
+        />
       </div>
 
       <div text-sm op-fade line-clamp-3 text-ellipsis mt--1 mb1>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Hi.

Before, the provenance badge was only visible in the main sidebar when a package was selected.

Now, the same badge also appears in each package card.

Here's what it looks like:

<img width="1835" height="846" alt="image" src="https://github.com/user-attachments/assets/e4e335de-2756-442c-9035-eb95bc767819" />


### Linked Issues

Fix: https://github.com/antfu/node-modules-inspector/issues/134

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
