### PR TITLE
fix: prevent long package names from overflowing card header

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/PackageName.vue
+++ b/packages/node-modules-inspector/src/app/components/display/PackageName.vue
@@ -5,5 +5,5 @@ defineProps<{
 </script>
 
 <template>
-  <span font-mono>{{ name }}</span>
+ <span font-mono break-all>{{ name }}</span>
 </template>


### PR DESCRIPTION
Closes #104

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [x ] <- Keep this line and put an `x` between the brackts.

## Description

Closes #104

Package names without hyphens (e.g. `eslintpluginreactrefresh`) overflow the card boundary and push icons out of the card in grid view.

Added `break-all` utility class to `DisplayPackageName` component so long names wrap at the card edge.

## Changes

- `packages/node-modules-inspector/src/app/components/display/PackageName.vue`: add `break-all` to `<span>`

<!-- e.g. is there anything you'd like reviewers to focus on? -->
