### PR TITLE
feat: show provenance badge on grid view cards

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/PackageName.vue
+++ b/packages/node-modules-inspector/src/app/components/display/PackageName.vue
@@ -5,5 +5,5 @@ defineProps<{
 </script>
 
 <template>
- <span font-mono break-all>{{ name }}</span>
+  <span font-mono break-all>{{ name }}</span>
 </template>

--- a/packages/node-modules-inspector/src/app/components/display/ProvenanceBadge.vue
+++ b/packages/node-modules-inspector/src/app/components/display/ProvenanceBadge.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { PackageNode } from 'node-modules-tools'
+import { Tooltip } from 'floating-vue'
+import { computed } from 'vue'
+import { getNpmMeta } from '../../state/payload'
+
+const props = defineProps<{
+  pkg: PackageNode
+}>()
+
+const meta = computed(() => getNpmMeta(props.pkg))
+</script>
+
+<template>
+  <Tooltip v-if="meta?.provenance">
+    <div i-ph:circle-wavy-check-duotone text-primary-400 text-sm />
+    <template #popper>
+      This package is built and signed
+      {{ meta.provenance === 'trustedPublisher' ? 'by trusted publisher' : 'with provenance' }}
+    </template>
+  </Tooltip>
+</template>

--- a/packages/node-modules-inspector/src/app/components/grid/Item.vue
+++ b/packages/node-modules-inspector/src/app/components/grid/Item.vue
@@ -17,7 +17,10 @@ defineProps<{
     inner="flex flex-col gap-2 justify-center h-full hover:bg-active p2 px3"
     @click="selectedNode = pkg === selectedNode ? undefined : pkg"
   >
-    <DisplayPackageSpec :pkg text-left />
+    <div flex="~ gap-2 items-center" text-left>
+      <DisplayPackageSpec :pkg />
+      <DisplayProvenanceBadge :pkg />
+    </div>
     <div flex="~ wrap gap-2 items-center" text-sm>
       <DisplayModuleType :pkg />
       <DisplayNumberBadge

--- a/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { PackageNode } from 'node-modules-tools'
-import { Tooltip, Menu as VMenu } from 'floating-vue'
+import { Menu as VMenu } from 'floating-vue'
 import { computed, nextTick, watch } from 'vue'
 import { useRouter } from '#app/composables/router'
 import { getBackend } from '../../backends'
@@ -216,13 +216,7 @@ const thirdPartyServices = computed(() => {
           :class="deprecation?.latest ? deprecation.type === 'future' ? 'text-orange line-through' : 'text-red line-through' : ''"
         />
 
-        <Tooltip v-if="meta?.provenance">
-          <div i-ph:circle-wavy-check-duotone text-primary-400 text-sm />
-          <template #popper>
-            This package is built and signed
-            {{ meta.provenance === 'trustedPublisher' ? 'by trusted publisher' : 'with provenance' }}
-          </template>
-        </Tooltip>
+        <DisplayProvenanceBadge :pkg />
       </div>
 
       <div text-sm op-fade line-clamp-3 text-ellipsis mt--1 mb1>


### PR DESCRIPTION
### Description

Closes #134 — the npm provenance badge is now visible on each card in the grid view, so users can see provenance status at a glance without opening the detail panel.

This is a rework of #135 following [@antfu's review feedback](https://github.com/antfu/node-modules-inspector/pull/135#discussion_r2403078660): instead of embedding the badge inside `PackageSpec` (which would silently broadcast it to every consumer — tree, chart, graph, reports), the badge is added at the grid call site only. `PackageSpec` stays narrowly responsible for name/version/deprecation/vulnerability styling.

A new `ProvenanceBadge.vue` component is extracted from the existing inline tooltip in `PackageDetails.vue` and reused in both places.

### Linked Issues

Fix: #134
Reworks: #135