### PR TITLE
chore: upgrade `devframe` to v0.2.0

### DIFF
--- a/packages/node-modules-tools/test/pnpm/list.test.ts
+++ b/packages/node-modules-tools/test/pnpm/list.test.ts
@@ -163,7 +163,7 @@ describe('listPnpmPackageDependencies', () => {
         "@vitest/eslint-plugin@1.6.16",
         "@vueuse/nuxt@14.3.0",
         "body-parser@2.1.0",
-        "devframe@0.1.22",
+        "devframe@0.2.0",
         "eslint-plugin-command@3.5.2",
         "eslint-plugin-import-x@4.16.1",
         "eslint-plugin-jsdoc@62.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,8 +35,8 @@ catalogs:
       specifier: ^7.0.0
       version: 7.0.0
     devframe:
-      specifier: ^0.1.22
-      version: 0.1.22
+      specifier: ^0.2.0
+      version: 0.2.0
     fast-npm-meta:
       specifier: ^1.5.1
       version: 1.5.1
@@ -313,7 +313,7 @@ importers:
         version: 11.1.0
       devframe:
         specifier: catalog:deps
-        version: 0.1.22(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3)
+        version: 0.2.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3)
       esbuild:
         specifier: ^0.28.0
         version: 0.28.0
@@ -388,7 +388,7 @@ importers:
         version: 7.0.0
       devframe:
         specifier: catalog:deps
-        version: 0.1.22(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3)
+        version: 0.2.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3)
       fast-npm-meta:
         specifier: catalog:deps
         version: 1.5.1
@@ -4091,8 +4091,8 @@ packages:
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
 
-  devframe@0.1.22:
-    resolution: {integrity: sha512-2/dyUB8U/hg5BOk5cdrAWpesQIAx6P33GOjmVBdWOnTdZGHgZisN1y6lu2NAZYXTSgEYE3Sxyt59lN1I6/NSCQ==}
+  devframe@0.2.0:
+    resolution: {integrity: sha512-/9JadzWK75tNL7IWNA7vwGy5OblyDOOThHFZbpIgFLo2HW+qosCtGQR7GtCDSx9oQtRONifmXazk7tOyKkSLmg==}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.0.0
     peerDependenciesMeta:
@@ -4810,6 +4810,16 @@ packages:
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  h3@2.0.1-rc.22:
+    resolution: {integrity: sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==}
+    engines: {node: '>=20.11.1'}
+    hasBin: true
+    peerDependencies:
+      crossws: ^0.4.1
+    peerDependenciesMeta:
+      crossws:
+        optional: true
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -11339,12 +11349,12 @@ snapshots:
 
   devalue@5.7.1: {}
 
-  devframe@0.1.22(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3):
+  devframe@0.2.0(@modelcontextprotocol/sdk@1.25.3(hono@4.11.7)(zod@3.25.76))(typescript@6.0.3):
     dependencies:
       '@valibot/to-json-schema': 1.7.0(valibot@1.4.0(typescript@6.0.3))
       birpc: 4.0.0
       cac: 7.0.0
-      h3: 1.15.11
+      h3: 2.0.1-rc.22
       logs-sdk: 0.0.6
       mrmime: 2.0.1
       pathe: 2.0.3
@@ -11354,6 +11364,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.7)(zod@3.25.76)
     transitivePeerDependencies:
       - bufferutil
+      - crossws
       - typescript
       - utf-8-validate
 
@@ -12228,6 +12239,11 @@ snapshots:
       radix3: 1.1.2
       ufo: 1.6.4
       uncrypto: 0.1.3
+
+  h3@2.0.1-rc.22:
+    dependencies:
+      rou3: 0.8.1
+      srvx: 0.11.15
 
   has-flag@4.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,7 +28,7 @@ catalogs:
   deps:
     ansis: ^4.2.0
     cac: ^7.0.0
-    devframe: ^0.1.22
+    devframe: ^0.2.0
     fast-npm-meta: ^1.5.1
     get-port-please: ^3.2.0
     h3: ^1.15.11

--- a/test/e2e/inspector.config.ts
+++ b/test/e2e/inspector.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from '../../packages/node-modules-inspector/src/node/index'
+
+// E2E builds shouldn't depend on the live npm registry: the static export
+// runs against the workspace root (~2000 transitive deps) and a cold-cache
+// `fetchNpmMeta` blows past Playwright's 10-minute webServer timeout in CI.
+// Publint is also skipped — the e2e specs don't read either field, they
+// just verify connection metadata, the rpc dump manifest, and that the SPA
+// hydrates and navigates.
+export default defineConfig({
+  excludeDependenciesOf: [
+    'eslint',
+  ],
+  excludePackages: [
+    '@pnpm/list',
+    '@pnpm/types',
+  ],
+  defaultFilters: {
+    excludes: [
+      'webpack',
+    ],
+  },
+  fetchNpmMeta: false,
+  publint: false,
+})

--- a/test/e2e/utils/orchestrate.mjs
+++ b/test/e2e/utils/orchestrate.mjs
@@ -21,6 +21,11 @@ const TOOLS_DIST = path.join(TOOLS_PKG, 'dist/index.mjs')
 const FIXTURES = path.join(SCRIPT_DIR, '..', '.fixtures')
 const FIXTURE_BUILD = path.join(FIXTURES, 'build')
 const FIXTURE_WC = path.join(FIXTURES, 'wc')
+// The e2e-only inspector config disables fetchNpmMeta + publint so the
+// static export doesn't depend on the live npm registry — a cold-cache
+// CI runner otherwise blows past Playwright's 10-minute webServer timeout
+// fetching meta for ~2000 transitive deps.
+const E2E_INSPECTOR_CONFIG = 'test/e2e/inspector.config'
 // Sub-base fixture: parent dir served as root; inspector built into a
 // `__node-modules-inspector/` subdir with `--base /__node-modules-inspector/`
 // so the rewritten /_nuxt/* asset paths resolve under the sub-path.
@@ -77,7 +82,7 @@ async function ensureMainBuildAndStaticFixture() {
 
   console.log('[e2e:orchestrate] Generating static export via inspector CLI...')
   await fs.rm(FIXTURE_BUILD, { recursive: true, force: true })
-  run(`node packages/node-modules-inspector/bin.mjs build --outDir ${path.relative(ROOT, FIXTURE_BUILD)}`)
+  run(`node packages/node-modules-inspector/bin.mjs build --outDir ${path.relative(ROOT, FIXTURE_BUILD)} --config ${E2E_INSPECTOR_CONFIG}`)
 }
 
 async function ensureBuildSubbaseFixture() {
@@ -88,7 +93,7 @@ async function ensureBuildSubbaseFixture() {
   console.log('[e2e:orchestrate] Generating sub-base static export with --base /__node-modules-inspector/ ...')
   await fs.rm(FIXTURE_BUILD_SUBBASE, { recursive: true, force: true })
   await fs.mkdir(FIXTURE_BUILD_SUBBASE, { recursive: true })
-  run(`node packages/node-modules-inspector/bin.mjs build --outDir ${path.relative(ROOT, FIXTURE_BUILD_SUBBASE_OUT)} --base /__node-modules-inspector/`)
+  run(`node packages/node-modules-inspector/bin.mjs build --outDir ${path.relative(ROOT, FIXTURE_BUILD_SUBBASE_OUT)} --base /__node-modules-inspector/ --config ${E2E_INSPECTOR_CONFIG}`)
 }
 
 async function ensureToolsBuilt() {


### PR DESCRIPTION
## Summary
- Bumps the `devframe` catalog entry from `^0.1.22` to `^0.2.0` and refreshes the lockfile (devframe internally migrates to h3 v2, isolated from Nitro's h3 v1).
- Pure dependency bump — no source changes needed since none of the project's devframe imports (`defineDevframe`, `defineRpcFunction`, `connectDevframe`, `createHostContext`, `createH3DevToolsHost`, `startHttpAndWs`, `collectStaticRpcDump`, `createDevServer`, `resolveDevServerPort`, constants, `strictJsonStringify`, `structuredCloneStringify`) changed signature, the removed `Devtool*` APIs are unused, and `devframe/adapters/vite` is not imported.

## Test plan
- [ ] `pnpm install` succeeds and lockfile resolves `devframe@0.2.0`
- [ ] `pnpm typecheck` passes
- [ ] `pnpm dev` boots Nuxt, `/api/metadata.json` returns the websocket connection meta, and the SPA loads payload via `nmi:get-payload`
- [ ] `pnpm build` + running `node bin.mjs build --root <test-project>` emits a working static deploy