### PR TITLE
feat: add support for rush monorepos

### DIFF
--- a/packages/node-modules-tools/src/agent-entry/detect.ts
+++ b/packages/node-modules-tools/src/agent-entry/detect.ts
@@ -1,8 +1,16 @@
 import type { AgentName } from 'package-manager-detector'
 import type { BaseOptions } from '../types'
+import { existsSync } from 'node:fs'
 import { detect } from 'package-manager-detector'
+import { join } from 'pathe'
 
-export async function getPackageManager(options: BaseOptions): Promise<AgentName> {
+export type AgentNameExtended = AgentName | 'rush-pnpm'
+
+export async function getPackageManager(options: BaseOptions): Promise<AgentNameExtended> {
+  // Detect Rush monorepo before generic detection
+  if (existsSync(join(options.cwd, 'rush.json'))) {
+    return 'rush-pnpm'
+  }
   const manager = await detect({
     cwd: options.cwd,
   })

--- a/packages/node-modules-tools/src/agent-entry/list.ts
+++ b/packages/node-modules-tools/src/agent-entry/list.ts
@@ -1,5 +1,5 @@
-import type { AgentName } from 'package-manager-detector'
 import type { ListPackageDependenciesBaseResult, ListPackageDependenciesOptions, ListPackageDependenciesRawResult, PackageNodeBase } from '../types'
+import type { AgentNameExtended } from './detect'
 
 /**
  * List dependencies of packages in the current project.
@@ -7,7 +7,7 @@ import type { ListPackageDependenciesBaseResult, ListPackageDependenciesOptions,
  * This function will automatically detect the package manager in the current project, and list the dependencies of the packages.
  */
 export async function listPackageDependenciesRaw(
-  manager: AgentName,
+  manager: AgentNameExtended,
   options: ListPackageDependenciesOptions,
 ): Promise<ListPackageDependenciesBaseResult> {
   let result: ListPackageDependenciesRawResult
@@ -17,6 +17,8 @@ export async function listPackageDependenciesRaw(
     result = await import('../agents/npm').then(r => r.listPackageDependencies(options))
   else if (manager === 'bun')
     result = await import('../agents/bun').then(r => r.listPackageDependencies(options))
+  else if (manager === 'rush-pnpm')
+    result = await import('../agents/rush').then(r => r.listPackageDependencies(options))
   else
     throw new Error(`Package manager ${manager} is not yet supported`)
 

--- a/packages/node-modules-tools/src/agents/pnpm/core.ts
+++ b/packages/node-modules-tools/src/agents/pnpm/core.ts
@@ -1,0 +1,251 @@
+import type { PackageDependencyHierarchy } from '@pnpm/list'
+import type { ProjectManifest } from '@pnpm/types'
+import type { ListPackageDependenciesOptions, ListPackageDependenciesRawResult, PackageNodeRaw } from '../../types'
+import fs from 'node:fs'
+import YAML from 'js-yaml'
+import { dirname, join, relative } from 'pathe'
+import { x } from 'tinyexec'
+import { CLUSTER_DEP_DEV, CLUSTER_DEP_PROD } from '../../constants'
+import { JsonParseStreamError } from '../../json-parse-stream'
+
+export interface PnpmAgentOptions {
+  executable: string
+  packageManagerName: string
+}
+
+type PnpmPackageNode = Pick<ProjectManifest, 'description' | 'license' | 'author' | 'homepage'> & {
+  alias: string | undefined
+  version: string
+  path: string
+  resolved?: string
+  from: string
+  repository?: string
+  dependencies?: Record<string, PnpmPackageNode>
+}
+
+type PnpmDependencyHierarchy = Pick<PackageDependencyHierarchy, 'name' | 'version' | 'path'>
+  & Required<Pick<PackageDependencyHierarchy, 'private'>>
+  & {
+    dependencies?: Record<string, PnpmPackageNode>
+    devDependencies?: Record<string, PnpmPackageNode>
+    optionalDependencies?: Record<string, PnpmPackageNode>
+    unsavedDependencies?: Record<string, PnpmPackageNode>
+  }
+
+async function resolveRoot(executable: string, options: ListPackageDependenciesOptions) {
+  let raw: string | undefined
+  if (options.workspace === false) {
+    try {
+      raw = (await x(executable, ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+        .stdout
+        .trim()
+    }
+    catch (err) {
+      console.error('Failed to resolve root directory')
+      console.error(err)
+    }
+  }
+  else {
+    try {
+      raw = (await x(executable, ['root', '-w'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+        .stdout
+        .trim()
+    }
+    catch {
+      try {
+        raw = (await x(executable, ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+          .stdout
+          .trim()
+      }
+      catch (err) {
+        console.error('Failed to resolve root directory')
+        console.error(err)
+      }
+    }
+  }
+  return raw ? dirname(raw) : options.cwd
+}
+
+async function getVersion(executable: string, options: ListPackageDependenciesOptions) {
+  try {
+    const raw = await x(executable, ['--version'], { throwOnError: true, nodeOptions: { cwd: options.cwd } })
+    return raw.stdout.trim()
+  }
+  catch (err) {
+    console.error(`Failed to get ${executable} version`)
+    console.error(err)
+    return undefined
+  }
+}
+
+async function getDependenciesTree(executable: string, options: ListPackageDependenciesOptions): Promise<PnpmDependencyHierarchy[]> {
+  const args = ['ls', '--json', '--depth', String(options.depth)]
+  if (options.monorepo)
+    args.push('--recursive')
+  if (options.workspace === false)
+    args.push('--ignore-workspace')
+  const process = x(executable, args, {
+    throwOnError: true,
+    nodeOptions: {
+      stdio: 'pipe',
+      cwd: options.cwd,
+    },
+  })
+
+  const json = await import('../../json-parse-stream')
+    .then(r => r.parseJsonStreamWithConcatArrays<PnpmDependencyHierarchy>(process.process!.stdout!, `${executable} ls`))
+    .catch((err) => {
+      if (err instanceof JsonParseStreamError) {
+        try {
+          if (err.data.error?.message === 'Invalid string length') {
+            console.error(`${executable} ls output is too large to parse, please try using the --depth=${String(Math.ceil(options.depth / 3 * 2))} option to limit the depth of the dependency tree`)
+          }
+        }
+        catch {}
+      }
+      throw err
+    })
+
+  if (!Array.isArray(json))
+    throw new Error(`Failed to parse \`${executable} ls\` output, expected an array but got: ${String(json)}`)
+
+  return json
+}
+
+export async function getCatalogs(root: string): Promise<Record<string, Record<string, string>>> {
+  if (!fs.existsSync(join(root, 'pnpm-workspace.yaml')))
+    return {}
+  const raw = await fs.promises.readFile(join(root, 'pnpm-workspace.yaml'), 'utf-8')
+  const data = YAML.load(raw) as any || {}
+  return {
+    ...data.catalogs || {},
+    default: data.catalog,
+  }
+}
+
+export async function listPackageDependenciesWithExecutable(
+  options: ListPackageDependenciesOptions,
+  agentOptions: PnpmAgentOptions,
+): Promise<ListPackageDependenciesRawResult> {
+  const { executable, packageManagerName } = agentOptions
+  const root = await resolveRoot(executable, options) || options.cwd
+  const tree = await getDependenciesTree(executable, options)
+  const catalogsMap = await getCatalogs(root)
+  const packages = new Map<string, PackageNodeRaw>()
+
+  const workspacePackages = tree.map((pkg) => {
+    let name = pkg.name
+    if (!name) {
+      let path = relative(root, pkg.path)
+      if (path === '.')
+        path = ''
+      const suffix = path.toLowerCase().replace(/[^a-z0-9-]+/g, '_').slice(0, 20)
+      name = suffix ? `#workspace-${suffix}` : '#workspace-root'
+    }
+    const version = pkg.version || '0.0.0'
+    const node: PackageNodeRaw = {
+      spec: `${name}@${version}`,
+      name,
+      version,
+      filepath: pkg.path,
+      dependencies: new Set(),
+      workspace: true,
+      clusters: new Set(),
+    }
+    if (pkg.private)
+      node.private = true
+    packages.set(node.spec, node)
+    return {
+      pkg,
+      node,
+    }
+  })
+
+  const mapNormalize = new WeakMap<PnpmPackageNode, PackageNodeRaw>()
+  function normalize(raw: PnpmPackageNode): PackageNodeRaw {
+    let node = mapNormalize.get(raw)
+    if (node)
+      return node
+
+    // Resolve workspace package version
+    let version = raw.version
+    if (version.includes(':')) {
+      const workspaceMapping = workspacePackages.find(i => i.pkg.path === raw.path)
+      if (workspaceMapping)
+        version = workspaceMapping.node.version
+    }
+
+    const spec = `${raw.from}@${version}`
+
+    node = packages.get(spec) || {
+      spec,
+      name: raw.from,
+      version,
+      filepath: raw.path,
+      dependencies: new Set(),
+      clusters: new Set(),
+    }
+    mapNormalize.set(raw, node)
+    return node
+  }
+
+  function traverse(
+    raw: PnpmPackageNode,
+    level: number,
+    clusters: Iterable<string>,
+  ): PackageNodeRaw {
+    const node = normalize(raw)
+
+    if (!node.workspace) {
+      for (const cluster of clusters) {
+        node.clusters.add(cluster)
+      }
+    }
+
+    if (!node.workspace && level === 1) {
+      const catalogs = Object.entries(catalogsMap)
+        .filter(([_, catalog]) => catalog?.[node.name])
+        .map(([name]) => name)
+      for (const catalog of catalogs) {
+        node.clusters.add(`catalog:${catalog}`)
+      }
+    }
+
+    // Filter out node
+    if (options.traverseFilter?.(node) === false)
+      return node
+
+    if (packages.has(node.spec))
+      return node
+
+    packages.set(node.spec, node)
+
+    if (options.dependenciesFilter?.(node) !== false) {
+      for (const dep of Object.values(raw.dependencies || {})) {
+        const resolvedDep = traverse(dep, level + 1, clusters)
+        node.dependencies.add(resolvedDep.spec)
+      }
+    }
+
+    return node
+  }
+
+  // Traverse deps
+  for (const { pkg, node } of workspacePackages) {
+    for (const dep of Object.values(pkg.dependencies || {})) {
+      const result = traverse(dep, 1, [CLUSTER_DEP_PROD])
+      node.dependencies.add(result.spec)
+    }
+    for (const dep of Object.values(pkg.devDependencies || {})) {
+      const result = traverse(dep, 1, [CLUSTER_DEP_DEV])
+      node.dependencies.add(result.spec)
+    }
+  }
+
+  return {
+    root,
+    packageManager: packageManagerName,
+    packageManagerVersion: await getVersion(executable, options),
+    packages,
+  }
+}

--- a/packages/node-modules-tools/src/agents/rush/index.ts
+++ b/packages/node-modules-tools/src/agents/rush/index.ts
@@ -1,0 +1,1 @@
+export { listPackageDependencies } from './list'

--- a/packages/node-modules-tools/src/agents/rush/list.ts
+++ b/packages/node-modules-tools/src/agents/rush/list.ts
@@ -1,11 +1,11 @@
 import type { ListPackageDependenciesOptions, ListPackageDependenciesRawResult } from '../../types'
-import { listPackageDependenciesWithExecutable } from './core'
+import { listPackageDependenciesWithExecutable } from '../pnpm/core'
 
 export async function listPackageDependencies(
   options: ListPackageDependenciesOptions,
 ): Promise<ListPackageDependenciesRawResult> {
   return listPackageDependenciesWithExecutable(options, {
-    executable: 'pnpm',
-    packageManagerName: 'pnpm',
+    executable: 'rush-pnpm',
+    packageManagerName: 'rush-pnpm',
   })
 }

--- a/packages/node-modules-tools/src/resolve.ts
+++ b/packages/node-modules-tools/src/resolve.ts
@@ -1,5 +1,5 @@
-import type { AgentName } from 'package-manager-detector'
 import type { PackageJson } from 'pkg-types'
+import type { AgentNameExtended } from './agent-entry/detect'
 import type { BaseOptions, PackageNode, PackageNodeBase } from './types'
 import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
@@ -43,7 +43,7 @@ export const PACKAGE_JSON_KEYS = [
  * - Set `module` to the resolved module type (cjs, esm, dual, faux, none).
  */
 export async function resolvePackage(
-  _packageManager: AgentName,
+  _packageManager: AgentNameExtended,
   pkg: PackageNodeBase,
   _options: BaseOptions,
 ): Promise<PackageNode> {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #139

### ✅ Context

Rush monorepos use pnpm under the hood but require the `rush-pnpm` wrapper
to correctly locate workspace files. The inspector currently does not
recognize Rush projects.

### 📦 Description

- Detect Rush monorepos by checking for `rush.json` in the project root
- Refactor pnpm agent logic into a shared `core.ts` with a configurable
  executable parameter (`PnpmAgentOptions`)
- Add a new `rush` agent that reuses the pnpm core logic with `rush-pnpm`
  as the executable
- Route `rush-pnpm` in the agent dispatcher

**Files changed:**
- `agents/pnpm/core.ts` — new shared core with `listPackageDependenciesWithExecutable()`
- `agents/pnpm/list.ts` — thin wrapper calling core with `executable: 'pnpm'`
- `agents/rush/index.ts` — new rush agent entry
- `agents/rush/list.ts` — calls core with `executable: 'rush-pnpm'`
- `agent-entry/detect.ts` — rush.json detection + `AgentNameExtended` type
- `agent-entry/list.ts` — add `rush-pnpm` routing

No new dependencies added. Rush ships `rush-pnpm` out of the box.