### PR TITLE
feat(tools): add `unknown` module type for native binary addons

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/ModuleType.ts
+++ b/packages/node-modules-inspector/src/app/components/display/ModuleType.ts
@@ -36,6 +36,8 @@ export default defineComponent({
         return 'Package that ships non-standard module format, that might work with some bundlers but not Node.js'
       if (type.value === 'dts')
         return 'Package that ships TypeScript types'
+      if (type.value === 'unknown')
+        return 'Package that is neither CJS nor ESM (e.g. native binary addon)'
     })
 
     return () => {

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -2,8 +2,8 @@ import type { PackageModuleType, PackageNode } from 'node-modules-tools'
 import { computed } from 'vue'
 import { settings } from '../state/settings'
 
-export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts'] as PackageModuleType[]
-export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs'] as PackageModuleType[]
+export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts', 'unknown'] as PackageModuleType[]
+export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs', 'unknown'] as PackageModuleType[]
 
 // @unocss-include
 export const MODULE_TYPES_COLOR_BADGE = {
@@ -34,6 +34,8 @@ export function getModuleType(node: PackageNode | PackageModuleType) {
 
   if (type === 'dts')
     return 'dts'
+  if (type === 'unknown')
+    return 'unknown'
   if (['cjs', 'faux'].includes(type))
     return 'cjs'
   return 'esm'

--- a/packages/node-modules-tools/src/analyze-esm.ts
+++ b/packages/node-modules-tools/src/analyze-esm.ts
@@ -67,6 +67,10 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   if (pkgJson.name?.startsWith('@types/'))
     return 'dts'
 
+  // Native binary addon packages are neither CJS nor ESM
+  if (isNativeAddon(pkgJson))
+    return 'unknown'
+
   const hasExports = pkgJson.exports != null
   const hasModule = !!pkgJson.module
   const hasMain = !!pkgJson.main
@@ -115,5 +119,21 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   if (pkgJson.types || pkgJson.typings)
     return 'dts'
 
-  return 'cjs'
+  if (hasExports)
+    return 'cjs'
+
+  return 'unknown'
+}
+
+function isNativeAddon(pkgJson: PackageJson): boolean {
+  const main = pkgJson.main
+  // .node file as main entry
+  if (main && main.endsWith('.node'))
+    return true
+  // Has gypfile (node-gyp) indicator without any JS entry point
+  if ((pkgJson as Record<string, unknown>).gypfile && !pkgJson.exports && !pkgJson.module) {
+    if (!main || main.endsWith('.node'))
+      return true
+  }
+  return false
 }

--- a/packages/node-modules-tools/src/constants.ts
+++ b/packages/node-modules-tools/src/constants.ts
@@ -1,6 +1,6 @@
 import type { PackageModuleType } from './types'
 
-export const PackageModuleTypes: readonly PackageModuleType[] = Object.freeze(['cjs', 'esm', 'dual', 'faux', 'dts'])
+export const PackageModuleTypes: readonly PackageModuleType[] = Object.freeze(['cjs', 'esm', 'dual', 'faux', 'dts', 'unknown'])
 
 export const CLUSTER_DEP_PROD = 'dep:prod'
 export const CLUSTER_DEP_DEV = 'dep:dev'

--- a/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
+++ b/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
@@ -112,4 +112,27 @@ export const packageJsonSnapshots = {
       },
     },
   },
+  'native-addon-with-node-main (#124)': {
+    expected: 'unknown',
+    packageJson: {
+      name: 'some-native-addon',
+      version: '1.0.0',
+      main: './build/Release/addon.node',
+    },
+  },
+  'native-addon-gypfile (#124)': {
+    expected: 'unknown',
+    packageJson: {
+      name: 'some-gyp-addon',
+      version: '1.0.0',
+      gypfile: 'true',
+    } as any,
+  },
+  'empty-package-no-entry (#124)': {
+    expected: 'unknown',
+    packageJson: {
+      name: 'empty-package',
+      version: '1.0.0',
+    },
+  },
 } satisfies Record<string, PackageJsonSnapshotFixture>


### PR DESCRIPTION
### Linked issue

Resolves #124

### Context

Native `.node` binary addons and packages without any JS entry point are incorrectly classified as CJS by default. The `unknown` type has been added to `PackageModuleType` (already defined in `types/node.ts`), but the detection logic and UI support are still missing.

### Description

- Add `unknown` to `PackageModuleTypes` constant array
- Add `isNativeAddon()` detection for `.node` main entries and `gypfile` packages
- Fallback to `unknown` instead of `cjs` for packages with no JS entry point
- Add UI support: filter, tooltip description, and `getModuleType` handling
- Add test fixtures for native addon scenarios