### PR TITLE
feat(inspector): sortable maintainer actions + run-publint-all

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/VersionWithUpdates.vue
+++ b/packages/node-modules-inspector/src/app/components/display/VersionWithUpdates.vue
@@ -4,10 +4,13 @@ import { Tooltip } from 'floating-vue'
 import semver from 'semver'
 import { computed } from 'vue'
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   version?: string
   latest?: NpmMetaLatest | null
-}>()
+  displayVersion?: boolean
+}>(), {
+  displayVersion: true,
+})
 
 const versionDiff = computed(() => {
   if (!props.latest || !props.version)
@@ -25,7 +28,7 @@ const updateAvailable = computed(() => {
 <template>
   <Tooltip v-if="version">
     <div flex="~ items-center gap-1">
-      <DisplayVersion :version="version" op75 />
+      <DisplayVersion v-if="props.displayVersion" :version="version" op75 />
       <template v-if="latest">
         <div v-if="latest.version === version || !updateAvailable" text-sm op-fade>
           <div i-ph-calendar-check-duotone />

--- a/packages/node-modules-inspector/src/app/components/report/MaintainerActions.vue
+++ b/packages/node-modules-inspector/src/app/components/report/MaintainerActions.vue
@@ -1,15 +1,59 @@
 <script setup lang="ts">
 import type { ParsedAuthor } from 'node-modules-tools/utils'
 import type { MaintainerActionGroup, MaintainerActionItem } from '../../state/maintainer-actions'
-import { selectedAction } from '../../state/current'
+import { computed, ref } from 'vue'
+import { getBackend } from '../../backends'
+import { selectedAction, selectedNode } from '../../state/current'
+import { fetchPublintMessages, rawPayload, rawPublintMessages } from '../../state/data'
 import {
   authorKey,
   filteredMaintainerActionGroups,
   maintainerActionAuthors,
   maintainerActionGroups,
+  maintainerActionSortMode,
   maintainerFilter,
   viewAllMaintainerActions,
 } from '../../state/maintainer-actions'
+import { getNpmMetaLatest, payloads } from '../../state/payload'
+
+const SORT_OPTIONS = ['depth', 'migration', 'latest'] as const
+const SORT_TITLES = ['Depth', 'Migration rate', 'Latest released']
+
+const backend = getBackend()
+
+const publintRunning = ref(false)
+const publintDone = ref(0)
+const publintTotal = ref(0)
+
+const pendingPublintCandidates = computed(() =>
+  payloads.filtered.packages.filter(p =>
+    !p.workspace
+    && !p.private
+    && p.filepath
+    && !p.resolved.publint
+    && !rawPublintMessages.value.has(p.spec),
+  ),
+)
+
+async function runPublintForAll() {
+  if (publintRunning.value)
+    return
+  const candidates = pendingPublintCandidates.value
+  if (!candidates.length)
+    return
+  publintRunning.value = true
+  publintDone.value = 0
+  publintTotal.value = candidates.length
+  try {
+    await Promise.all(candidates.map(async (pkg) => {
+      await fetchPublintMessages(pkg)
+      publintDone.value++
+    }))
+  }
+  finally {
+    publintRunning.value = false
+  }
+}
 
 function selectItem(item: MaintainerActionItem) {
   viewAllMaintainerActions.value = false
@@ -20,6 +64,7 @@ function openGroupAll(group: MaintainerActionGroup) {
   const first = group.items[0]
   if (!first)
     return
+  selectedNode.value = group.consumer
   selectedAction.value = first
   viewAllMaintainerActions.value = true
 }
@@ -54,14 +99,33 @@ function ratioPct(migrationRatio: number) {
         Packages with actionable improvements for maintainers, including out-of-range dependency declarations and publint findings.
       </div>
 
+      <div v-if="backend.isDynamic && rawPayload?.config?.publint && (pendingPublintCandidates.length || publintRunning)" mt3>
+        <button
+          btn-action
+          :disabled="publintRunning"
+          @click="runPublintForAll()"
+        >
+          <div :class="publintRunning ? 'i-ph-spinner-gap-duotone animate-spin' : 'i-ph-book-open-duotone'" />
+          {{ publintRunning ? `Running publint... (${publintDone}/${publintTotal})` : 'Run Publint for all packages' }}
+        </button>
+      </div>
+
       <div v-if="maintainerActionAuthors.length" mb2 border="~ base rounded-md" flex="~ col gap-3" p3 mt4>
-        <div text-xs op-fade flex="~ items-center gap-1" h-5 px1>
+        <div text-xs flex="~ items-center gap-1" h-5 px1>
           <div i-ph-user-duotone />
           Maintainers
-          <button v-if="maintainerFilter.length" border rounded-full px2 py1 text-xs op-fade flex="~ items-center gap-1" hover:op100 ml-2 @click="clearFilter()">
+          <button v-if="maintainerFilter.length" border="~ base rounded-full" px2 py1 text-xs op-fade flex="~ items-center gap-1" hover:op100 ml-2 @click="clearFilter()">
             <div i-ph-funnel-x-duotone />
             Clear Filter
           </button>
+          <div ml-auto flex="~ items-center gap-1">
+            <span op-fade mr1>Sort by</span>
+            <OptionSelectGroup
+              v-model="maintainerActionSortMode"
+              :options="SORT_OPTIONS"
+              :titles="SORT_TITLES"
+            />
+          </div>
         </div>
         <div flex="~ wrap gap-2 items-center">
           <button
@@ -79,6 +143,14 @@ function ratioPct(migrationRatio: number) {
             <DisplayAuthorEntry :author="author" :link="false" :size="22" />
           </button>
         </div>
+      </div>
+      <div v-else mb2 border="~ base rounded-md" flex="~ items-center gap-1" px3 py2 mt4 text-xs>
+        <span op-fade mr1>Sort by</span>
+        <OptionSelectGroup
+          v-model="maintainerActionSortMode"
+          :options="SORT_OPTIONS"
+          :titles="SORT_TITLES"
+        />
       </div>
 
       <template v-if="filteredMaintainerActionGroups.length">
@@ -102,9 +174,12 @@ function ratioPct(migrationRatio: number) {
               >
                 <DisplayPackageSpec :pkg="group.consumer" />
               </button>
-              <div v-if="group.consumer.workspace" badge-color-lime px2 rounded text-xs>
-                Workspace
-              </div>
+              <DisplayVersionWithUpdates
+                :version="group.consumer.version"
+                :latest="getNpmMetaLatest(group.consumer)"
+                :display-version="false"
+              />
+              <DisplayDateBadge :pkg="group.consumer" />
               <DisplayAuthors v-if="group.authors.length" :authors="group.authors" :size="20" />
               <div ml-auto flex="~ items-center gap-2">
                 <DisplayNumberBadge :number="group.items.length" rounded-full text-xs />

--- a/packages/node-modules-inspector/src/app/state/maintainer-actions.ts
+++ b/packages/node-modules-inspector/src/app/state/maintainer-actions.ts
@@ -4,7 +4,7 @@ import semver from 'semver'
 import { computed } from 'vue'
 import { compareSemver } from '../utils/semver'
 import { rawPayload, rawPublintMessages } from './data'
-import { payloads } from './payload'
+import { getPublishTime, payloads } from './payload'
 import { query } from './query'
 
 export function authorKey(author: ParsedAuthor): string {
@@ -240,7 +240,20 @@ export interface MaintainerActionGroup {
   authors: ParsedAuthor[]
   items: MaintainerActionItem[]
   maxMigrationRatio: number
+  latestReleasedAt: number
 }
+
+export type MaintainerActionSortMode = 'depth' | 'migration' | 'latest'
+
+export const maintainerActionSortMode = computed<MaintainerActionSortMode>({
+  get: () => {
+    const v = query.actionSort
+    return v === 'migration' || v === 'latest' ? v : 'depth'
+  },
+  set: (v) => {
+    query.actionSort = v === 'depth' ? undefined : v
+  },
+})
 
 function getConsumerAuthors(pkg: PackageNode): ParsedAuthor[] {
   const list = pkg.resolved.authors
@@ -270,6 +283,7 @@ export const maintainerActionGroups = computed<MaintainerActionGroup[]>(() => {
         authors: getConsumerAuthors(item.consumer),
         items: [],
         maxMigrationRatio: 0,
+        latestReleasedAt: getPublishTime(item.consumer)?.getTime() ?? 0,
       }
       byConsumer.set(item.consumer.spec, group)
     }
@@ -281,23 +295,34 @@ export const maintainerActionGroups = computed<MaintainerActionGroup[]>(() => {
   for (const group of byConsumer.values())
     group.items.sort(actionSortKey)
 
-  return Array.from(byConsumer.values()).sort((a, b) =>
-    (a.depth - b.depth)
-    || (b.maxMigrationRatio - a.maxMigrationRatio)
-    || a.consumer.name.localeCompare(b.consumer.name),
-  )
+  const groups = Array.from(byConsumer.values())
+  const mode = maintainerActionSortMode.value
+  const nameTie = (a: MaintainerActionGroup, b: MaintainerActionGroup) =>
+    a.consumer.name.localeCompare(b.consumer.name)
+  const cmp: (a: MaintainerActionGroup, b: MaintainerActionGroup) => number
+    = mode === 'migration'
+      ? (a, b) => (b.maxMigrationRatio - a.maxMigrationRatio) || (a.depth - b.depth) || nameTie(a, b)
+      : mode === 'latest'
+        ? (a, b) => (b.latestReleasedAt - a.latestReleasedAt) || (a.depth - b.depth) || nameTie(a, b)
+        : (a, b) => (a.depth - b.depth) || (b.maxMigrationRatio - a.maxMigrationRatio) || nameTie(a, b)
+  return groups.sort(cmp)
 })
 
 export const maintainerActionAuthors = computed<ParsedAuthor[]>(() => {
-  const map = new Map<string, ParsedAuthor>()
+  const map = new Map<string, { author: ParsedAuthor, count: number }>()
   for (const group of maintainerActionGroups.value) {
     for (const author of group.authors) {
       const key = authorKey(author)
-      if (!map.has(key))
-        map.set(key, author)
+      const entry = map.get(key)
+      if (entry)
+        entry.count++
+      else
+        map.set(key, { author, count: 1 })
     }
   }
-  return Array.from(map.values()).sort((a, b) => authorKey(a).localeCompare(authorKey(b)))
+  return Array.from(map.values())
+    .sort((a, b) => (b.count - a.count) || authorKey(a.author).localeCompare(authorKey(b.author)))
+    .map(e => e.author)
 })
 
 export const maintainerFilter = computed<string[]>({

--- a/packages/node-modules-inspector/src/app/state/query.ts
+++ b/packages/node-modules-inspector/src/app/state/query.ts
@@ -11,6 +11,7 @@ export interface QueryOptions extends Partial<{ [x in keyof FilterOptions]?: str
   selectedAction?: string
   selectedAuthors?: string
   actionAll?: string
+  actionSort?: string
 }
 
 export const query = reactive<QueryOptions>({
@@ -19,6 +20,7 @@ export const query = reactive<QueryOptions>({
   selectedAction: '',
   selectedAuthors: '',
   actionAll: '',
+  actionSort: '',
 } as any)
 
 function camelCase(str: string) {


### PR DESCRIPTION
## Summary

- Add sort modes for the Maintainer Actions groups — **Depth** (default), **Migration rate**, **Latest released** — exposed via an `OptionSelectGroup` and persisted in the URL hash as `action-sort`. "Latest released" sorts by the consumer package's own publish time.
- Sort the maintainer filter chips by the number of action groups each maintainer is associated with (desc, alphabetical tie-break) instead of alphabetically.
- Group header now shows the consumer's update indicator (`DisplayVersionWithUpdates` with new `display-version=false` prop) and publish-time badge; clicking the package spec also sets `selectedNode` so it's highlighted elsewhere.
- New "Run Publint for all packages" button (visible only on dynamic backends with publint enabled) batches `fetchPublintMessages` across pending candidates with a `(done/total)` progress label, and hides itself once everything is cached.

## Test plan

- [ ] Open Maintainer Actions in a workspace with multiple groups; switch between Depth / Migration rate / Latest released and confirm reorder + `action-sort` query param.
- [ ] Confirm maintainer chips are ordered by group count, and filter + sort combine correctly.
- [ ] Confirm group header shows the update arrow + tooltip and publish-time badge for the consumer; clicking the spec highlights the package.
- [ ] On a dev backend with `publint: true`, click "Run Publint for all packages" and verify progress, cached short-circuit, and that the button disappears once all candidates are publinted.