### PR TITLE
fix(inspector): auto-expand sidepanel when a node is selected

### DIFF
--- a/packages/node-modules-inspector/src/app/state/current.ts
+++ b/packages/node-modules-inspector/src/app/state/current.ts
@@ -2,12 +2,15 @@ import { computed } from 'vue'
 import { findMaintainerActionByKey } from './maintainer-actions'
 import { payloads } from './payload'
 import { query } from './query'
+import { settings } from './settings'
 
 export const selectedNode = computed({
   get() {
     return query.selected ? payloads.main.get(query.selected) : undefined
   },
   set(v) {
+    if (v)
+      settings.value.collapseSidepanel = false
     query.selected = v?.spec
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

When the side panel is collapsed, selecting a package does not automatically expand it,it still remains in the collapsed state.

before:
<img width="2091" height="1144" alt="screenshot-1779332549502" src="https://github.com/user-attachments/assets/04720538-a626-41d3-a3bb-782caae0125c" />

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!-- If you used AI tools to help with this contribution, please ensure the PR description and code reflect your own understanding.
     Write in your own voice rather than copying AI-generated text. -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thanks for your contribution!
----------------------------------------------------------------------->
