### PR TITLE
feat(inspector): group dependencies tree by catalog or module type

### DIFF
--- a/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
+++ b/packages/node-modules-inspector/src/app/components/panel/PackageDetails.vue
@@ -54,6 +54,24 @@ function getDepth(amount: number, min = 1) {
   return 10
 }
 
+const GROUP_BY_CYCLE = ['none', 'catalog', 'module'] as const
+
+const groupByMeta = computed(() => {
+  switch (settings.value.dependenciesGroupBy) {
+    case 'catalog':
+      return { icon: 'i-ph-exclude-duotone', label: 'Catalog' }
+    case 'module':
+      return { icon: 'i-ph-cube-duotone', label: 'Module' }
+    default:
+      return { icon: 'i-ph-list-duotone', label: 'None' }
+  }
+})
+
+function cycleDependenciesGroupBy() {
+  const idx = GROUP_BY_CYCLE.indexOf(settings.value.dependenciesGroupBy)
+  settings.value.dependenciesGroupBy = GROUP_BY_CYCLE[(idx + 1) % GROUP_BY_CYCLE.length]!
+}
+
 const publint = computed(() => {
   if (props.pkg.resolved.publint)
     return props.pkg.resolved.publint
@@ -375,7 +393,15 @@ const thirdPartyServices = computed(() => {
           :number="settings.deepDependenciesTree ? payloads.available.flatDependencies(pkg).length : payloads.available.dependencies(pkg).length"
         />
       </button>
-      <div border="b base" pt2 px2>
+      <div border="b base" pt2 px2 flex="~ items-center gap-1">
+        <button
+          v-tooltip="`Group dependencies by: ${groupByMeta.label}`"
+          p1 rounded-full hover:bg-active
+          :title="`Group dependencies by: ${groupByMeta.label}`"
+          @click="cycleDependenciesGroupBy"
+        >
+          <div op75 :class="groupByMeta.icon" />
+        </button>
         <button
           v-tooltip="'Toggle deep dependencies tree'"
           p1 rounded-full hover:bg-active
@@ -396,6 +422,7 @@ const thirdPartyServices = computed(() => {
             :currents="getShallowestDependents(pkg)"
             :list="payloads.available.flatDependents(pkg)"
             :max-depth="getDepth(payloads.available.flatDependents(pkg).length, 2)"
+            :group-by="settings.dependenciesGroupBy"
             type="dependents"
           />
           <TreeDependencies
@@ -404,6 +431,7 @@ const thirdPartyServices = computed(() => {
             :currents="payloads.available.dependents(pkg)"
             :list="payloads.available.dependents(pkg)"
             :max-depth="getDepth(payloads.available.dependents(pkg).length, 2)"
+            :group-by="settings.dependenciesGroupBy"
             type="dependents"
           />
         </template>
@@ -435,6 +463,7 @@ const thirdPartyServices = computed(() => {
             :currents="payloads.available.dependencies(pkg)"
             :list="payloads.available.flatDependencies(pkg)"
             :max-depth="getDepth(payloads.available.flatDependencies(pkg).length)"
+            :group-by="settings.dependenciesGroupBy"
             type="dependencies"
           />
         </template>

--- a/packages/node-modules-inspector/src/app/components/tree/Dependencies.vue
+++ b/packages/node-modules-inspector/src/app/components/tree/Dependencies.vue
@@ -9,10 +9,14 @@ const props = withDefaults(defineProps<{
   seen?: string[]
   depth?: number
   maxDepth?: number
+  groupBy?: 'none' | 'catalog' | 'module'
 }>(), {
   depth: 1,
   maxDepth: 6,
+  groupBy: 'none',
 })
+
+const NO_CATALOG = '__no_catalog__'
 
 const seen = computed(() => {
   return [...props.seen || [], ...props.currents?.map(i => i.spec) || []]
@@ -37,29 +41,108 @@ const tree = computed(() => {
     })
     .sort((a, b) => (b.children?.length || 0) - (a.children?.length || 0))
 })
+
+function getGroupKey(pkg: PackageNode, mode: 'catalog' | 'module'): string {
+  if (mode === 'catalog') {
+    for (const c of pkg.clusters) {
+      if (c.startsWith('catalog:'))
+        return c
+    }
+    return NO_CATALOG
+  }
+  return pkg.resolved.module
+}
+
+const groups = computed(() => {
+  if (props.groupBy === 'none' || props.depth !== 1)
+    return null
+  const mode = props.groupBy
+  const map = new Map<string, PackageNode[]>()
+  for (const pkg of props.currents || []) {
+    if (!pkg)
+      continue
+    const key = getGroupKey(pkg, mode)
+    let group = map.get(key)
+    if (!group) {
+      group = []
+      map.set(key, group)
+    }
+    group.push(pkg)
+  }
+  const keys = Array.from(map.keys())
+  keys.sort((a, b) => {
+    if (mode === 'catalog') {
+      const order = (k: string) => k === NO_CATALOG ? 2 : k === 'catalog:default' ? 1 : 0
+      const oa = order(a)
+      const ob = order(b)
+      if (oa !== ob)
+        return oa - ob
+      return a.localeCompare(b)
+    }
+    if (a === 'unknown')
+      return 1
+    if (b === 'unknown')
+      return -1
+    return a.localeCompare(b)
+  })
+  return keys.map(key => ({
+    key,
+    pkgs: map.get(key)!,
+  }))
+})
+
+function getGroupLabel(key: string): string {
+  if (props.groupBy === 'catalog')
+    return key === NO_CATALOG ? 'No catalog' : key
+  return key.toUpperCase()
+}
 </script>
 
 <template>
   <div flex="~ col gap-1">
-    <template v-for="{ pkg, children } of tree" :key="pkg.spec">
-      <TreeItem :pkg="pkg" />
-      <template v-if="children?.length">
-        <RenderNextTick v-if="props.depth < props.maxDepth">
-          <TreeDependencies
-            ml4
-            :currents="children"
-            :list="props.list"
-            :type="props.type"
-            :seen="seen"
-            :depth="props.depth + 1"
-            :max-depth="props.maxDepth"
+    <template v-if="groups">
+      <div v-for="group of groups" :key="group.key" flex="~ col gap-1">
+        <div flex="~ items-center gap-1" mt2 mb1>
+          <DisplayClusterBadge
+            v-if="props.groupBy === 'catalog' && group.key !== NO_CATALOG"
+            :cluster="group.key"
           />
-        </RenderNextTick>
-        <div v-else-if="props.maxDepth > 2" ml6>
-          <span op-fade px2 bg-active rounded text-sm>
-            {{ children?.length }} more ···
-          </span>
+          <div v-else op-fade text-sm>
+            {{ getGroupLabel(group.key) }}
+          </div>
         </div>
+        <TreeDependencies
+          :currents="group.pkgs"
+          :list="props.list"
+          :type="props.type"
+          :seen="seen"
+          :depth="props.depth"
+          :max-depth="props.maxDepth"
+          group-by="none"
+        />
+      </div>
+    </template>
+    <template v-else>
+      <template v-for="{ pkg, children } of tree" :key="pkg.spec">
+        <TreeItem :pkg="pkg" />
+        <template v-if="children?.length">
+          <RenderNextTick v-if="props.depth < props.maxDepth">
+            <TreeDependencies
+              ml4
+              :currents="children"
+              :list="props.list"
+              :type="props.type"
+              :seen="seen"
+              :depth="props.depth + 1"
+              :max-depth="props.maxDepth"
+            />
+          </RenderNextTick>
+          <div v-else-if="props.maxDepth > 2" ml6>
+            <span op-fade px2 bg-active rounded text-sm>
+              {{ children?.length }} more ···
+            </span>
+          </div>
+        </template>
       </template>
     </template>
   </div>

--- a/packages/node-modules-inspector/src/app/state/settings.ts
+++ b/packages/node-modules-inspector/src/app/state/settings.ts
@@ -8,6 +8,7 @@ export const settings = useLocalStorage<SettingsOptions>(
     moduleTypeSimple: false,
     moduleTypeRender: 'badge',
     deepDependenciesTree: true,
+    dependenciesGroupBy: 'none',
     packageDetailsTab: 'dependents',
     colorizePackageSize: true,
     showInstallSizeBadge: true,

--- a/packages/node-modules-inspector/src/shared/types.ts
+++ b/packages/node-modules-inspector/src/shared/types.ts
@@ -75,6 +75,7 @@ export interface SettingsOptions {
   moduleTypeSimple: boolean
   moduleTypeRender: 'badge' | 'circle' | 'none'
   deepDependenciesTree: boolean
+  dependenciesGroupBy: 'none' | 'catalog' | 'module'
   packageDetailsTab: 'dependencies' | 'dependents'
   colorizePackageSize: boolean
   showInstallSizeBadge: boolean


### PR DESCRIPTION
Adds a small icon button next to the deep-tree toggle in the package details panel that cycles the "Used by" / "Deps on" tree through three grouping modes: **None**, **Catalog**, and **Module**. Catalog mode addresses #51 / PR #53 — surfacing which pnpm catalog each direct dep comes from — while module mode (ESM / CJS / DUAL / …) gives a quick read on a package's module-type composition without leaving the tree view. The choice persists in localStorage alongside the other UI preferences, and grouping applies only at the top level so deep-tree expansion still works inside each section.

Created with the help of an agent.