### PR TITLE
feat(tools): add Rush monorepo support

### DIFF
--- a/packages/node-modules-tools/src/agent-entry/detect.ts
+++ b/packages/node-modules-tools/src/agent-entry/detect.ts
@@ -1,8 +1,16 @@
 import type { AgentName } from 'package-manager-detector'
 import type { BaseOptions } from '../types'
 import { detect } from 'package-manager-detector'
+import { isRushMonorepo } from '../utils/rush'
 
 export async function getPackageManager(options: BaseOptions): Promise<AgentName> {
+  // Rush monorepos use pnpm under the hood via `rush-pnpm`.
+  // Detect Rush first so the pnpm agent can pick the right executable.
+  if (isRushMonorepo(options.cwd)) {
+    options.rush = true
+    return 'pnpm'
+  }
+
   const manager = await detect({
     cwd: options.cwd,
   })

--- a/packages/node-modules-tools/src/agents/pnpm/list.ts
+++ b/packages/node-modules-tools/src/agents/pnpm/list.ts
@@ -27,11 +27,16 @@ type PnpmDependencyHierarchy = Pick<PackageDependencyHierarchy, 'name' | 'versio
     unsavedDependencies?: Record<string, PnpmPackageNode>
   }
 
+function resolveExecutable(options: ListPackageDependenciesOptions): string {
+  return options.rush ? 'rush-pnpm' : 'pnpm'
+}
+
 async function resolveRoot(options: ListPackageDependenciesOptions) {
   let raw: string | undefined
+  const pnpmBin = resolveExecutable(options)
   if (options.workspace === false) {
     try {
-      raw = (await x('pnpm', ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+      raw = (await x(pnpmBin, ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
         .stdout
         .trim()
     }
@@ -42,13 +47,13 @@ async function resolveRoot(options: ListPackageDependenciesOptions) {
   }
   else {
     try {
-      raw = (await x('pnpm', ['root', '-w'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+      raw = (await x(pnpmBin, ['root', '-w'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
         .stdout
         .trim()
     }
     catch {
       try {
-        raw = (await x('pnpm', ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
+        raw = (await x(pnpmBin, ['root'], { throwOnError: true, nodeOptions: { cwd: options.cwd } }))
           .stdout
           .trim()
       }
@@ -63,23 +68,25 @@ async function resolveRoot(options: ListPackageDependenciesOptions) {
 
 async function getPnpmVersion(options: ListPackageDependenciesOptions) {
   try {
-    const raw = await x('pnpm', ['--version'], { throwOnError: true, nodeOptions: { cwd: options.cwd } })
+    const pnpmBin = resolveExecutable(options)
+    const raw = await x(pnpmBin, ['--version'], { throwOnError: true, nodeOptions: { cwd: options.cwd } })
     return raw.stdout.trim()
   }
   catch (err) {
-    console.error('Failed to get pnpm version')
+    console.error(`Failed to get ${resolveExecutable(options)} version`)
     console.error(err)
     return undefined
   }
 }
 
 async function getDependenciesTree(options: ListPackageDependenciesOptions): Promise<PnpmDependencyHierarchy[]> {
+  const pnpmBin = resolveExecutable(options)
   const args = ['ls', '--json', '--depth', String(options.depth)]
   if (options.monorepo)
     args.push('--recursive')
   if (options.workspace === false)
     args.push('--ignore-workspace')
-  const process = x('pnpm', args, {
+  const process = x(pnpmBin, args, {
     throwOnError: true,
     nodeOptions: {
       stdio: 'pipe',
@@ -93,7 +100,7 @@ async function getDependenciesTree(options: ListPackageDependenciesOptions): Pro
       if (err instanceof JsonParseStreamError) {
         try {
           if (err.data.error?.message === 'Invalid string length') {
-            console.error(`pnpm ls output is too large to parse, please try using the --depth=${String(Math.ceil(options.depth / 3 * 2))} option to limit the depth of the dependency tree`)
+            console.error(`${pnpmBin} ls output is too large to parse, please try using the --depth=${String(Math.ceil(options.depth / 3 * 2))} option to limit the depth of the dependency tree`)
           }
         }
         catch {}
@@ -102,7 +109,7 @@ async function getDependenciesTree(options: ListPackageDependenciesOptions): Pro
     })
 
   if (!Array.isArray(json))
-    throw new Error(`Failed to parse \`pnpm ls\` output, expected an array but got: ${String(json)}`)
+    throw new Error(`Failed to parse \`${pnpmBin} ls\` output, expected an array but got: ${String(json)}`)
 
   return json
 }

--- a/packages/node-modules-tools/src/types/base.ts
+++ b/packages/node-modules-tools/src/types/base.ts
@@ -3,4 +3,10 @@ export interface BaseOptions {
    * Current working directory
    */
   cwd: string
+  /**
+   * Whether the project is a Rush monorepo.
+   * When true, the pnpm agent will use `rush-pnpm` instead of `pnpm`.
+   * @internal
+   */
+  rush?: boolean
 }

--- a/packages/node-modules-tools/src/utils/index.ts
+++ b/packages/node-modules-tools/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './filter'
 export * from './package-json'
+export * from './rush'

--- a/packages/node-modules-tools/src/utils/rush.test.ts
+++ b/packages/node-modules-tools/src/utils/rush.test.ts
@@ -1,0 +1,40 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { findRushRoot, isRushMonorepo } from './rush'
+
+describe('rush detection', () => {
+  function createTempDir(): string {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'rush-test-'))
+  }
+
+  it('returns false when no rush.json exists', () => {
+    const dir = createTempDir()
+    expect(isRushMonorepo(dir)).toBe(false)
+    expect(findRushRoot(dir)).toBeUndefined()
+  })
+
+  it('detects rush.json at the current directory', () => {
+    const dir = createTempDir()
+    fs.writeFileSync(path.join(dir, 'rush.json'), '{}')
+    expect(isRushMonorepo(dir)).toBe(true)
+    expect(findRushRoot(dir)).toBe(dir)
+  })
+
+  it('detects rush.json in a parent directory', () => {
+    const root = createTempDir()
+    fs.writeFileSync(path.join(root, 'rush.json'), '{}')
+    const child = path.join(root, 'apps', 'web')
+    fs.mkdirSync(child, { recursive: true })
+
+    expect(isRushMonorepo(child)).toBe(true)
+    expect(findRushRoot(child)).toBe(root)
+  })
+
+  it('distinguishes rush.json from pnpm-workspace.yaml', () => {
+    const dir = createTempDir()
+    fs.writeFileSync(path.join(dir, 'pnpm-workspace.yaml'), 'packages: []')
+    expect(isRushMonorepo(dir)).toBe(false)
+  })
+})

--- a/packages/node-modules-tools/src/utils/rush.ts
+++ b/packages/node-modules-tools/src/utils/rush.ts
@@ -1,0 +1,32 @@
+import fs from 'node:fs'
+import { dirname, join, parse } from 'pathe'
+
+/**
+ * Check if the given directory is inside a Rush monorepo.
+ *
+ * Rush monorepos are identified by the presence of a `rush.json` file
+ * at the monorepo root. This function traverses up from `cwd` to find it.
+ *
+ * @see https://rushjs.io/pages/maintainer/setup_new_repo/
+ */
+export function isRushMonorepo(cwd: string): boolean {
+  return !!findRushRoot(cwd)
+}
+
+/**
+ * Find the Rush monorepo root directory by traversing up from `cwd`.
+ *
+ * @returns The directory containing `rush.json`, or `undefined` if not in a Rush monorepo.
+ */
+export function findRushRoot(cwd: string): string | undefined {
+  let dir = cwd
+  const { root } = parse(dir)
+
+  while (dir && dir !== root) {
+    if (fs.existsSync(join(dir, 'rush.json')))
+      return dir
+    dir = dirname(dir)
+  }
+
+  return undefined
+}


### PR DESCRIPTION
### Description

Closes #139

Add support for [Rush](https://rushjs.io) monorepos by detecting
`rush.json` and using `rush-pnpm` as the executable in the pnpm agent.

### How it works

Rush provides `rush-pnpm` — a transparent wrapper around the user's
`pnpm` binary that configures it to work within the Rush monorepo.
Since `rush-pnpm` accepts the same CLI arguments as `pnpm`, we only
need to swap the executable.

Detection strategy:
1. Before falling back to `package-manager-detector`, check for
   `rush.json` by traversing up from `cwd`.
2. If found, set `options.rush = true` and return `'pnpm'` as the agent.
3. The pnpm agent reads `options.rush` and uses `rush-pnpm` instead of `pnpm`.

### Changes

- `types/base.ts` — Add optional `rush?: boolean` to `BaseOptions`
- `utils/rush.ts` — New module: `isRushMonorepo()` and `findRushRoot()`
- `agent-entry/detect.ts` — Pre-check for Rush before `package-manager-detector`
- `agents/pnpm/list.ts` — Resolve executable dynamically via `resolveExecutable()`

### Notes

- `rush-pnpm` is CLI-compatible with `pnpm`, so `pnpm ls`, `pnpm root`, etc.
  work identically. No argument construction logic changes.
- `getCatalogs()` returns `{}` automatically for Rush projects since they
  don't have `pnpm-workspace.yaml`.
- No new dependency is introduced.

### Validations

- [x] Follow our [Code of Conduct]
- [x] Read the [Contributing Guide]
- [x] Check that there isn't already a PR that addresses the same issue

[Code of Conduct]: https://github.com/antfu/.github/blob/main/CODE_OF_CONDUCT.md
[Contributing Guide]: https://github.com/antfu/contribute