### PR TITLE
fix: small report nav ui fix

### DIFF
--- a/packages/node-modules-inspector/src/app/pages/report/[...report].vue
+++ b/packages/node-modules-inspector/src/app/pages/report/[...report].vue
@@ -10,6 +10,10 @@ const selected = computed(() => params.report?.[0] || 'all')
 
 <template>
   <div flex="~ gap-2 items-center wrap">
+    <NuxtLink btn-action as="button" :to="{ path: '/report', hash: location.hash }" exact-active-class="text-primary bg-primary:5">
+      <div i-ph-grid-four-duotone />
+      All
+    </NuxtLink>
     <NuxtLink btn-action as="button" :to="{ path: '/report/funding', hash: location.hash }" active-class="text-rose bg-rose:5">
       <div i-ph-heart-duotone />
       Funding
@@ -49,10 +53,6 @@ const selected = computed(() => params.report?.[0] || 'all')
     <NuxtLink btn-action as="button" :to="{ path: '/report/licenses', hash: location.hash }" active-class="text-primary bg-primary:5">
       <div i-ph-scales-duotone />
       Licenses
-    </NuxtLink>
-    <NuxtLink btn-action as="button" :to="{ path: '/report', hash: location.hash }" exact-active-class="text-primary bg-primary:5">
-      <div i-ph-grid-four-duotone />
-      All
     </NuxtLink>
   </div>
 

--- a/packages/node-modules-inspector/src/app/pages/report/[...report].vue
+++ b/packages/node-modules-inspector/src/app/pages/report/[...report].vue
@@ -50,7 +50,7 @@ const selected = computed(() => params.report?.[0] || 'all')
       <div i-ph-scales-duotone />
       Licenses
     </NuxtLink>
-    <NuxtLink btn-action as="button" :to="{ path: '/report', hash: location.hash }" active-class="text-primary bg-primary:5">
+    <NuxtLink btn-action as="button" :to="{ path: '/report', hash: location.hash }" exact-active-class="text-primary bg-primary:5">
       <div i-ph-grid-four-duotone />
       All
     </NuxtLink>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 🧭 Context

<!-- Brief background and why this change is needed -->

<!-- High-level summary of what changed -->

### 📚 Description

#### Before

<img width="1158" height="468" alt="image" src="https://github.com/user-attachments/assets/55a4335b-38b7-491a-9c7b-b21737417a43" />

1. When a tab other than "All" is selected, the "All" tab remains highlighted.
2. According to standard UI design conventions, the default tab displayed upon opening should be at the beginning of the navigation bar, not at the end.

#### After

<img width="1158" height="468" alt="image" src="https://github.com/user-attachments/assets/583fcc46-2db2-4a06-8ab0-49593497f6d2" />
