### PR TITLE
fix(npm): improve error message when root package.json is missing req…

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,0 +1,2 @@
+telemetry.enabled=false
+telemetry.consent=0

--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,2 +1,0 @@
-telemetry.enabled=false
-telemetry.consent=0

--- a/packages/node-modules-tools/src/agents/npm/list.ts
+++ b/packages/node-modules-tools/src/agents/npm/list.ts
@@ -101,9 +101,15 @@ export async function listPackageDependencies(
     resolveRoot(options),
   ])
 
-  if (!rootPackage)
-    throw new Error('Could not find root package.json')
-
+  if (!rootPackage) {
+    throw new Error(
+      'Could not find root package.json. '
+      + 'Make sure the root package.json has both `name` and `version` fields. '
+      + 'If you are in a monorepo, the root package.json may be missing `version` '
+      + '(some monorepos version workspaces independently). '
+      + 'Add a `version` field (e.g. `"version": "0.0.0"`) to fix this.',
+    )
+  }
   const packages = new Map<string, PackageNodeRaw>()
   // Used to link package deps with resolved version
   const packageSpecByLocation = new Map<string, string>()


### PR DESCRIPTION
Explain that the root package.json must have both `name` and `version` fields, which is a common cause of confusion in monorepos where the root may not have a `version` field.

Closes #125

### 🔗 Linked issue

Closes #125

### 🧭 Context

When the root `package.json` is missing `name` or `version`, the `queryDependencies` filter silently drops it, causing `rootPackage` to be `undefined`. The error message just says "Could not find root package.json" with no hint about what's actually wrong.

### 📚 Description

Updated the error message to explain that both `name` and `version` fields are required, and suggest adding `"version": "0.0.0"` as a fix for monorepos that don't version the root independently.
