### PR TITLE
fix: detect native binary packages as 'bin', and improve module type detection

### DIFF
--- a/packages/node-modules-inspector/src/app/components/display/ModuleType.ts
+++ b/packages/node-modules-inspector/src/app/components/display/ModuleType.ts
@@ -36,6 +36,9 @@ export default defineComponent({
         return 'Package that ships non-standard module format, that might work with some bundlers but not Node.js'
       if (type.value === 'dts')
         return 'Package that ships TypeScript types'
+      if (type.value === 'bin')
+        return 'Package that ships platform-specific binaries'
+      return 'Unknown module type'
     })
 
     return () => {

--- a/packages/node-modules-inspector/src/app/pages/chart/[...chart].vue
+++ b/packages/node-modules-inspector/src/app/pages/chart/[...chart].vue
@@ -119,16 +119,28 @@ const hoverVersions = computed(() => {
     .sort((a, b) => compareSemver(a.version, b.version))
 })
 
+const MODULE_TYPES_COLOR = {
+  esm: '#4ade80',
+  dual: '#2dd4bf',
+  cjs: '#facc15',
+  faux: '#a3e635',
+  bin: '#6991e0',
+  dts: '#60c5db',
+  other: () => baseShade.value,
+}
+
 // Legend entries for the current color mode (spectrum has none).
 const legend = computed<{ background: string, label: string }[] | undefined>(() => {
   switch (coloringMode.value) {
     case 'module':
       return [
-        { background: '#4ade80', label: 'ESM' },
-        { background: '#2dd4bf', label: 'Dual' },
-        { background: '#facc15', label: 'CJS' },
-        { background: '#a3e635', label: 'Faux' },
-        { background: baseShade.value, label: 'DTS' },
+        { background: MODULE_TYPES_COLOR.esm, label: 'ESM' },
+        { background: MODULE_TYPES_COLOR.dual, label: 'DUAL' },
+        { background: MODULE_TYPES_COLOR.cjs, label: 'CJS' },
+        { background: MODULE_TYPES_COLOR.faux, label: 'FAUX' },
+        { background: MODULE_TYPES_COLOR.bin, label: 'BIN' },
+        { background: MODULE_TYPES_COLOR.dts, label: 'DTS' },
+        { background: MODULE_TYPES_COLOR.other(), label: 'OTHER' },
       ]
     case 'age':
       return [
@@ -282,17 +294,19 @@ function getColor(node: TreeNode<PackageNode | undefined>) {
       const type = getModuleType(node.meta.resolved.module)
       switch (type) {
         case 'esm':
-          return '#4ade80'
+          return MODULE_TYPES_COLOR.esm
         case 'cjs':
-          return '#facc15'
+          return MODULE_TYPES_COLOR.cjs
         case 'dual':
-          return '#2dd4bf'
+          return MODULE_TYPES_COLOR.dual
         case 'faux':
-          return '#a3e635'
+          return MODULE_TYPES_COLOR.faux
+        case 'bin':
+          return MODULE_TYPES_COLOR.bin
         case 'dts':
-          return baseShade.value
+          return MODULE_TYPES_COLOR.dts
       }
-      return undefined
+      return MODULE_TYPES_COLOR.other()
     }
     case 'age':
       return getAgeColor(node.meta)

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -2,8 +2,8 @@ import type { PackageModuleType, PackageNode } from 'node-modules-tools'
 import { computed } from 'vue'
 import { settings } from '../state/settings'
 
-export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts'] as PackageModuleType[]
-export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs'] as PackageModuleType[]
+export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts', 'unknown'] as PackageModuleType[]
+export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs', 'unknown'] as PackageModuleType[]
 
 // @unocss-include
 export const MODULE_TYPES_COLOR_BADGE = {

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -2,8 +2,8 @@ import type { PackageModuleType, PackageNode } from 'node-modules-tools'
 import { computed } from 'vue'
 import { settings } from '../state/settings'
 
-export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts', 'unknown'] as PackageModuleType[]
-export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs', 'unknown'] as PackageModuleType[]
+export const MODULE_TYPES_FULL = ['dual', 'esm', 'faux', 'cjs', 'dts', 'bin', 'unknown'] as PackageModuleType[]
+export const MODULE_TYPES_FULL_SELECT = ['dual', 'esm', 'faux', 'cjs', 'bin', 'unknown'] as PackageModuleType[]
 
 // @unocss-include
 export const MODULE_TYPES_COLOR_BADGE = {
@@ -12,6 +12,7 @@ export const MODULE_TYPES_COLOR_BADGE = {
   cjs: 'badge-color-yellow',
   faux: 'badge-color-lime',
   dts: 'badge-color-gray',
+  bin: 'badge-color-blue',
   unknown: 'badge-color-gray',
 }
 
@@ -21,7 +22,8 @@ export const MODULE_TYPES_NAME = {
   cjs: 'CJS',
   faux: 'FAUX',
   dts: 'DTS',
-  unknown: '?',
+  bin: 'BIN',
+  unknown: 'OTH',
 }
 
 export function getModuleType(node: PackageNode | PackageModuleType) {
@@ -36,7 +38,9 @@ export function getModuleType(node: PackageNode | PackageModuleType) {
     return 'dts'
   if (['cjs', 'faux'].includes(type))
     return 'cjs'
-  return 'esm'
+  if (type === 'esm')
+    return 'esm'
+  return 'unknown'
 }
 
 export function getModuleTypeCounts(nodes: Iterable<PackageNode>) {

--- a/packages/node-modules-inspector/src/app/utils/module-type.ts
+++ b/packages/node-modules-inspector/src/app/utils/module-type.ts
@@ -38,7 +38,7 @@ export function getModuleType(node: PackageNode | PackageModuleType) {
     return 'dts'
   if (['cjs', 'faux'].includes(type))
     return 'cjs'
-  if (type === 'esm')
+  if (type === 'esm' || type === 'dual')
     return 'esm'
   return 'unknown'
 }

--- a/packages/node-modules-tools/src/analyze-esm.test.ts
+++ b/packages/node-modules-tools/src/analyze-esm.test.ts
@@ -24,6 +24,6 @@ describe('analyzePackageModuleType', () => {
   it('stops recursive export analysis after max depth', () => {
     expect(analyze({
       exports: nestExports(11, './index.mjs'),
-    })).toBe('cjs')
+    })).toBe('unknown')
   })
 })

--- a/packages/node-modules-tools/src/analyze-esm.ts
+++ b/packages/node-modules-tools/src/analyze-esm.ts
@@ -31,6 +31,8 @@ function analyzeExports(exports: unknown, depth = 0): ExportsAnalysis {
       result.hasImport = true
     else if (exports.endsWith('.cjs') || exports.endsWith('.cts'))
       result.hasRequire = true
+    else if (exports.endsWith('.node'))
+      return { hasImport: false, hasRequire: false, hasModule: false }
     return result
   }
 
@@ -66,6 +68,10 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   // @types/ packages are always type-only
   if (pkgJson.name?.startsWith('@types/'))
     return 'dts'
+
+  // // Native binary packages (e.g. @oxc-parser/binding-linux-x64-gnu)
+  if (pkgJson.main?.endsWith('.node'))
+    return 'unknown'
 
   const hasExports = pkgJson.exports != null
   const hasModule = !!pkgJson.module
@@ -115,5 +121,5 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   if (pkgJson.types || pkgJson.typings)
     return 'dts'
 
-  return 'cjs'
+  return 'unknown'
 }

--- a/packages/node-modules-tools/src/analyze-esm.ts
+++ b/packages/node-modules-tools/src/analyze-esm.ts
@@ -69,9 +69,9 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   if (pkgJson.name?.startsWith('@types/'))
     return 'dts'
 
-  // // Native binary packages (e.g. @oxc-parser/binding-linux-x64-gnu)
+  // Native binary packages (e.g. @oxc-parser/binding-linux-x64-gnu)
   if (pkgJson.main?.endsWith('.node'))
-    return 'unknown'
+    return 'bin'
 
   const hasExports = pkgJson.exports != null
   const hasModule = !!pkgJson.module
@@ -120,6 +120,17 @@ export function analyzePackageModuleType(pkgJson: PackageJson): PackageModuleTyp
   // Type-only packages (no main, no exports, but has types)
   if (pkgJson.types || pkgJson.typings)
     return 'dts'
+
+  if (pkgJson.os || pkgJson.cpu)
+    return 'bin'
+
+  if (pkgJson.type === 'commonjs')
+    return 'cjs'
+
+  // No exports/main/module/type at all: Node resolves the implicit
+  // `./index.js` entry as CommonJS
+  if (!hasExports && !hasMain)
+    return 'cjs'
 
   return 'unknown'
 }

--- a/packages/node-modules-tools/src/constants.ts
+++ b/packages/node-modules-tools/src/constants.ts
@@ -1,6 +1,6 @@
 import type { PackageModuleType } from './types'
 
-export const PackageModuleTypes: readonly PackageModuleType[] = Object.freeze(['cjs', 'esm', 'dual', 'faux', 'dts'])
+export const PackageModuleTypes: readonly PackageModuleType[] = Object.freeze(['cjs', 'esm', 'dual', 'faux', 'dts', 'unknown'])
 
 export const CLUSTER_DEP_PROD = 'dep:prod'
 export const CLUSTER_DEP_DEV = 'dep:dev'

--- a/packages/node-modules-tools/src/types/node.ts
+++ b/packages/node-modules-tools/src/types/node.ts
@@ -5,8 +5,8 @@ import type { PackageInstallSizeInfo } from './size'
 
 export type { PackageJson, PublintMessage }
 
-export type PackageModuleTypeSimple = 'cjs' | 'esm'
-export type PackageModuleType = 'cjs' | 'esm' | 'dual' | 'faux' | 'dts' | 'unknown'
+export type PackageModuleTypeSimple = 'cjs' | 'esm' | 'other'
+export type PackageModuleType = 'cjs' | 'esm' | 'dual' | 'faux' | 'dts' | 'bin' | 'unknown'
 
 export interface PackageNodeRaw {
   /** Package Name */

--- a/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
+++ b/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
@@ -95,6 +95,14 @@ export const packageJsonSnapshots = {
       },
     },
   },
+  '@oxc-parser/binding-linux-x64-gnu (#124)': {
+    expected: 'unknown',
+    packageJson: {
+      name: '@oxc-parser/binding-linux-x64-gnu',
+      version: '0.147.0',
+      main: 'parser.linux-x64-gnu.node',
+    },
+  },
   '@octokit/rest@22.0.1 (#128)': {
     expected: 'esm',
     packageJson: {

--- a/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
+++ b/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
@@ -153,6 +153,24 @@ export const packageJsonSnapshots = {
       ],
     },
   },
+  'theme-vitesse@1.0.0': {
+    expected: 'unknown',
+    packageJson: {
+      name: 'theme-vitesse',
+      version: '1.0.0',
+      license: 'MIT',
+      exports: {
+        './*': './*',
+      },
+      icon: 'icon.png',
+      files: [
+        'LICENSE.md',
+        'extra/*',
+        'icon.png',
+        'themes/*',
+      ],
+    },
+  },
   '@octokit/rest@22.0.1 (#128)': {
     expected: 'esm',
     packageJson: {

--- a/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
+++ b/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
@@ -96,11 +96,61 @@ export const packageJsonSnapshots = {
     },
   },
   '@oxc-parser/binding-linux-x64-gnu (#124)': {
-    expected: 'unknown',
+    expected: 'bin',
     packageJson: {
       name: '@oxc-parser/binding-linux-x64-gnu',
       version: '0.147.0',
       main: 'parser.linux-x64-gnu.node',
+    },
+  },
+  '@esbuild/darwin-arm64 (#124)': {
+    expected: 'bin',
+    packageJson: {
+      name: '@esbuild/darwin-arm64',
+      version: '0.28.2',
+      os: [
+        'darwin',
+      ],
+      cpu: [
+        'arm64',
+      ],
+    },
+  },
+  'anymatch@3.1.3': {
+    expected: 'cjs',
+    packageJson: {
+      name: 'anymatch',
+      version: '3.1.3',
+      description: 'Matches strings against configurable strings, globs, regular expressions, and/or functions',
+      files: [
+        'index.js',
+        'index.d.ts',
+      ],
+    },
+  },
+  'js-tokens@9.0.1': {
+    expected: 'cjs',
+    packageJson: {
+      name: 'js-tokens',
+      version: '9.0.1',
+      type: 'commonjs',
+      exports: './index.js',
+    },
+  },
+  'express@5.2.1': {
+    expected: 'cjs',
+    packageJson: {
+      name: 'express',
+      version: '5.2.1',
+      engines: {
+        node: '>= 18',
+      },
+      files: [
+        'LICENSE',
+        'Readme.md',
+        'index.js',
+        'lib/',
+      ],
     },
   },
   '@octokit/rest@22.0.1 (#128)': {


### PR DESCRIPTION
Native binding packages (e.g. `@oxc-parser/binding-linux-x64-gnu`) have a `main` field pointing to a `.node` file. These are native binaries, not CJS or ESM modules, but were incorrectly categorized as CJS. This PR detects `.node` files and labels them as `'unknown'`.

Fixes #124


### 🔗 Linked issue

Resolves #124

### 🧭 Context

Native binding packages are becoming more common (e.g. SWC, OXC, esbuild). Their `main` field points to a `.node` binary file. The current detection logic falls through to the default `'cjs'` return, which is misleading — these packages contain no JavaScript module at all.

### 📚 Description

- Detect `.node` extension in `main` field and return `'unknown'`
- Handle `.node` in `exports` string analysis (skip without setting import/require flags)
- Change default fallback from `'cjs'` to `'unknown'` for packages with no recognizable module entry
- Add `'unknown'` to `PackageModuleTypes`, `MODULE_TYPES_FULL`, and `MODULE_TYPES_FULL_SELECT`
- Add test fixture for `@oxc-parser/binding-linux-x64-gnu`
- Update max-depth fallback test expectation from `'cjs'` to `'unknown'`
