### PR TITLE
fix: fallback to LICENSE file when package.json has no license field

### DIFF
--- a/packages/node-modules-tools/src/resolve.ts
+++ b/packages/node-modules-tools/src/resolve.ts
@@ -6,6 +6,7 @@ import { readFile } from 'node:fs/promises'
 import { join } from 'pathe'
 import { resolvePackageJsonFields } from './resolve-json'
 import { getPackageInstallSize } from './size'
+import { detectLicenseFromFile } from './utils/package-json'
 
 /**
  * Analyze a package node, and return a resolved package node.
@@ -28,8 +29,16 @@ export async function resolvePackage(
     const content = await readFile(path, 'utf-8')
     const json = JSON.parse(stripBomTag(content)) as PackageJson
 
+    const resolved = resolvePackageJsonFields(json)
+
+    // Fallback: when package.json has no license field, try to detect
+    // the license from a LICENSE file in the package directory.
+    if (!resolved.license) {
+      resolved.license = detectLicenseFromFile(pkg.filepath)
+    }
+
     _pkg.resolved = {
-      ...resolvePackageJsonFields(json),
+      ...resolved,
       installSize: await getPackageInstallSize(_pkg),
     }
   }

--- a/packages/node-modules-tools/src/utils/package-json.ts
+++ b/packages/node-modules-tools/src/utils/package-json.ts
@@ -1,8 +1,20 @@
 import type { PackageJson } from '../types'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { toArray } from '@antfu/utils'
 
 const RE_GITHUB_SPONSORS = /^(?:https?:\/\/)?(?:www\.)?github\.com\/sponsors\/([\w.-]+)/i
 const RE_GITHUB_USER_URL = /^(?:https?:\/\/)?(?:www\.)?github\.com\/([\w.-]+)\/?$/i
+const RE_LICENSE_NAMES = /^(?:LICENSE|LICENCE|COPYING|NOTICE)(?:\.(?:md|txt))?$/i
+const LICENSE_PATTERNS: [RegExp, string][] = [
+  [/Permission is hereby granted.*?without restriction/i, 'MIT'],
+  [/ISC License/i, 'ISC'],
+  [/Apache License,?\s*Version 2\.0/i, 'Apache-2.0'],
+  [/Redistribution and use in source and binary forms.*?provided that the following conditions are met/i, 'BSD-3-Clause'],
+  [/Redistribution and use in source and binary forms.*?provided that the following conditions are met.*?Neither the name/i, 'BSD-3-Clause'],
+  [/Redistribution and use in source and binary forms.*?provided that the following conditions are met(?!.*Neither)/i, 'BSD-2-Clause'],
+  [/UNIVERSAL PUBLIC LICENSE/i, 'UPL-1.0'],
+]
 const RE_GITHUB_PROFILE_LIKE = /^(?:https?:\/\/)?(?:www\.)?github\.com\/([\w.-]+)/i
 const RE_GITHUB_NOREPLY = /^(?:\d+\+)?([\w.-]+)@users\.noreply\.github\.com$/i
 const RE_OPENCOLLECTIVE = /^(?:https?:\/\/)?(?:www\.)?opencollective\.com\/([\w.-]+)/i
@@ -125,6 +137,24 @@ export function normalizePkgFundings(json: PackageJson): ParsedFunding[] | undef
     return undefined
 
   return fundings.map(f => parseFunding(f)).filter(Boolean)
+}
+/**
+ * Detect the SPDX license identifier from a LICENSE file in the given directory.
+ */
+
+export function detectLicenseFromFile(dir: string): string | undefined {
+  if (!existsSync(dir))
+    return undefined
+
+  const files = readdirSync(dir)
+  const licenseFile = files.find(f => RE_LICENSE_NAMES.test(f))
+  if (!licenseFile)
+    return undefined
+  const content = readFileSync(join(dir, licenseFile), 'utf-8')
+  for (const [pattern, spdx] of LICENSE_PATTERNS) {
+    if (pattern.test(content))
+      return spdx
+  }
 }
 
 export interface RawAuthor {


### PR DESCRIPTION
Some packages like `require-like` don't declare a `license` field in package.json but ship a LICENSE file.
Read common license file names and infer the SPDX identifier from well-known license texts.

Closes #145

### 🔗 Linked issue

#145

### 🧭 Context

Some older packages like `require-like` don't declare a `license` field in
their `package.json` (this was common before npm standardized the field).
Instead, they ship a `LICENSE` file with the actual license text.

Currently, `normalizePkgLicense()` only reads from `package.json`, so these
packages show up as having no license at all in the inspector.


### 📚 Description

When `package.json` has no `license` or `licenses` field, fall back to
scanning common license file names (`LICENSE`, `LICENSE.md`, `LICENCE`, etc.)
in the package directory and infer the SPDX identifier from well-known
license text patterns.

**Changes:**

- Added `detectLicenseFromFile()` in `package-json.ts` that reads license
  files and matches text patterns for MIT, ISC, Apache-2.0, BSD-2-Clause,
  BSD-3-Clause, and UPL-1.0
- Updated `resolvePackage()` in `resolve.ts` to call the fallback when
  `normalizePkgLicense()` returns `undefined`
- Added unit tests covering all supported license types and edge cases

**Not changed:**

- The registry-based resolver (`registry/resolve.ts`) is unaffected — it
  has no filesystem access
- `normalizePkgLicense()` itself is untouched; the fallback is only applied
  in the filesystem-based `resolvePackage()`

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thanks for your contribution!
----------------------------------------------------------------------->
