### PR TITLE
fix: correct test fixtures for @octokit/rest and @octokit/core

### DIFF
--- a/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
+++ b/packages/node-modules-tools/test/fixtures/package-json-snapshots.ts
@@ -85,7 +85,6 @@ export const packageJsonSnapshots = {
       name: '@octokit/core',
       version: '7.0.5',
       type: 'module',
-      main: './dist-src/index.js',
       types: './dist-types/index.d.ts',
       exports: {
         '.': {
@@ -177,8 +176,6 @@ export const packageJsonSnapshots = {
       name: '@octokit/rest',
       version: '22.0.1',
       type: 'module',
-      main: './dist-src/index.js',
-      module: './dist-src/index.js',
       types: './dist-types/index.d.ts',
       exports: {
         '.': {


### PR DESCRIPTION
Remove incorrect `main` and `module` fields from test fixtures that don't exist in the actual npm packages. Both packages are ESM-only with only `type: "module"` and `exports` fields.

Fixes #128

### 🔗 Linked issue

Resolves #128

### 🧭 Context

The test fixtures for `@octokit/rest@22.0.1` and `@octokit/core@7.0.5` contained `main` and `module` fields that do not exist in the real npm packages. These are pure ESM packages that declare their module type solely via `type: "module"` and the `exports` field.

### 📚 Description

- Remove `main` field from `@octokit/core@7.0.5` fixture — the real package has no `main`
- Remove `main` and `module` fields from `@octokit/rest@22.0.1` fixture — the real package has neither
- Verified that `analyzePackageModuleType` correctly returns `'esm'` for both packages using the actual package.json data from npm
- Detection logic in `analyze-esm.ts` does not need changes

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.
- Add any additional context, tradeoffs, follow-ups, or things reviewers should be aware of.

Thanks for your contribution!
----------------------------------------------------------------------->
